### PR TITLE
Amélioration du mixin commun aux vues

### DIFF
--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -4,29 +4,15 @@ from django.urls import reverse
 from django.views.generic import CreateView
 
 from inclusion_connect.accounts import forms
+from inclusion_connect.oidc_overrides.views import OIDCSessionMixin
 
 
-class OidcArgumentMixin:
-    def get_success_url(self):
-        # FIXME What to do if there's no next_url ?
-        # Is there a case when i would happend ?
-        # Maybe add a session token that we can pass every in every url ?
-        return self.request.session["next_url"]
-
-    def dispatch(self, request, *args, **kwargs):
-        next_url = request.GET.get("next")
-        if next_url:
-            request.session["next_url"] = next_url
-            request.session.modified = True
-        return super().dispatch(request, *args, **kwargs)
-
-
-class LoginView(OidcArgumentMixin, auth_views.LoginView):
+class LoginView(OIDCSessionMixin, auth_views.LoginView):
     form_class = forms.LoginForm
     template_name = "login.html"
 
 
-class RegistrationView(OidcArgumentMixin, CreateView):
+class RegistrationView(OIDCSessionMixin, CreateView):
     form_class = forms.RegistrationForm
     template_name = "registration.html"
 
@@ -55,7 +41,7 @@ class PasswordResetView(auth_views.PasswordResetView):
         return reverse("accounts:login")
 
 
-class PasswordResetConfirmView(OidcArgumentMixin, auth_views.PasswordResetConfirmView):
+class PasswordResetConfirmView(OIDCSessionMixin, auth_views.PasswordResetConfirmView):
     template_name = "password_reset_confirm.html"
     form_class = forms.SetPasswordForm
     post_reset_login = True

--- a/inclusion_connect/keycloak_compat/tests.py
+++ b/inclusion_connect/keycloak_compat/tests.py
@@ -31,7 +31,8 @@ def test_keycloak_urls_compat(client, realm):
     }
     auth_complete_url = add_url_params(auth_url, auth_params)
     response = client.get(auth_complete_url)
-    assertRedirects(response, add_url_params(reverse("accounts:login"), {"next": auth_complete_url}))
+    assertRedirects(response, reverse("accounts:login"))
+    assert client.session["next_url"] == auth_complete_url
 
     # Test AUTH endpoint when not authenticated and with bad params
     bad_auth_params = auth_params.copy()

--- a/inclusion_connect/oidc_overrides/tests.py
+++ b/inclusion_connect/oidc_overrides/tests.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from pytest_django.asserts import assertRedirects
 
 from inclusion_connect.oidc_overrides.factories import ApplicationFactory
+from inclusion_connect.oidc_overrides.views import OIDCSessionMixin
 from inclusion_connect.users.factories import UserFactory
 from inclusion_connect.utils.urls import add_url_params
 
@@ -64,7 +65,9 @@ def test_authorize_not_authenticated(client):
     }
     auth_complete_url = add_url_params(auth_url, auth_params)
     response = client.get(auth_complete_url)
-    assertRedirects(response, add_url_params(reverse("accounts:login"), {"next": auth_complete_url}))
+    assertRedirects(response, reverse("accounts:login"))
+    assert client.session["next_url"] == auth_complete_url
+    assert client.session[OIDCSessionMixin.OIDC_SESSION_KEY] == auth_params
 
 
 def test_registrations_bad_params(client):
@@ -96,4 +99,6 @@ def test_registrations_not_authenticated(client):
     }
     auth_complete_url = add_url_params(auth_url, auth_params)
     response = client.get(auth_complete_url)
-    assertRedirects(response, add_url_params(reverse("accounts:registration"), {"next": auth_complete_url}))
+    assertRedirects(response, reverse("accounts:registration"))
+    assert client.session["next_url"] == auth_complete_url
+    assert client.session[OIDCSessionMixin.OIDC_SESSION_KEY] == auth_params


### PR DESCRIPTION
### Pourquoi ?

Cette nouvelle version permet de stocker la prochaine url à visiter (et donc à facilement intercaler des étapes avant de rediriger vers le flow OIDC)
Elle permet aussi d'accéder facilement aux paramètres GET d'entrée dans les vues de Login / Register / Activation

