### PR TITLE
Changer la durée des session Django à 30 minutes

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -1,2 +1,4 @@
 [
+  "0 3 * * * $ROOT/clevercloud/run_management_command.sh clearsessions",
+  "0 3 * * * $ROOT/clevercloud/run_management_command.sh cleartokens"
 ]

--- a/inclusion_connect/keycloak_compat/tests.py
+++ b/inclusion_connect/keycloak_compat/tests.py
@@ -5,11 +5,11 @@ import pytest
 from django.contrib.auth import get_user
 from django.contrib.auth.hashers import PBKDF2PasswordHasher
 from django.urls import reverse
-from oauth2_provider.models import get_access_token_model, get_id_token_model, get_refresh_token_model
 from pytest_django.asserts import assertRedirects
 
 from inclusion_connect.keycloak_compat.hashers import KeycloakPasswordHasher
 from inclusion_connect.oidc_overrides.factories import DEFAULT_CLIENT_SECRET, ApplicationFactory, default_client_secret
+from inclusion_connect.test import token_are_revoked
 from inclusion_connect.users.factories import UserFactory
 from inclusion_connect.utils.urls import add_url_params, get_url_params
 
@@ -94,9 +94,7 @@ def test_login(client, realm):
     logout_params = {"id_token_hint": id_token}
     response = client.get(add_url_params(reverse(f"keycloak_compat_{realm}:logout"), logout_params))
     assert not get_user(client).is_authenticated
-    assert get_id_token_model().objects.count() == 0
-    assert get_access_token_model().objects.count() == 0
-    assert get_refresh_token_model().objects.get().revoked is not None
+    assert token_are_revoked(user)
 
 
 @pytest.mark.parametrize("realm", ["local", "Review_apps", "Demo", "inclusion-connect"])
@@ -190,9 +188,7 @@ def test_registration(client, realm):
     logout_params = {"id_token_hint": id_token}
     response = client.get(add_url_params(reverse(f"keycloak_compat_{realm}:logout"), logout_params))
     assert not get_user(client).is_authenticated
-    assert get_id_token_model().objects.count() == 0
-    assert get_access_token_model().objects.count() == 0
-    assert get_refresh_token_model().objects.get().revoked is not None
+    assert token_are_revoked(user)
 
 
 def test_password_hasher(client):

--- a/inclusion_connect/oidc_overrides/tests.py
+++ b/inclusion_connect/oidc_overrides/tests.py
@@ -1,4 +1,6 @@
+import pytest
 from django.contrib.auth import get_user
+from django.test.client import Client
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -6,7 +8,7 @@ from pytest_django.asserts import assertRedirects
 
 from inclusion_connect.oidc_overrides.factories import ApplicationFactory
 from inclusion_connect.oidc_overrides.views import OIDCSessionMixin
-from inclusion_connect.tests import OIDC_PARAMS
+from inclusion_connect.test import OIDC_PARAMS, has_ongoing_sessions, oidc_complete_flow, token_are_revoked
 from inclusion_connect.users.factories import UserFactory
 from inclusion_connect.users.models import UserApplicationLink
 from inclusion_connect.utils.urls import add_url_params
@@ -24,20 +26,82 @@ def test_allow_wildcard_in_redirect_uris():
     assert not application.redirect_uri_allowed("http://site1.mydomain.com/callback")
 
 
-def test_logout(client):
-    auth_url = reverse("oidc_overrides:authorize")
+@pytest.mark.parametrize(
+    "method,other_client",
+    [("get", True), ("get", False), ("post", True), ("post", False)],
+)
+def test_logout(client, method, other_client):
+    """This test simulates a GET or POST on logout endpoint from RP backend or the user browser"""
     user = UserFactory()
-    client.force_login(user)
-    response = client.get(auth_url)
-    assert response.status_code == 400  # auth_url is missing all the arguments
-    # TODO: Add a method to quickly to the oidc dance.
+    id_token = oidc_complete_flow(client, user)
+
+    assert get_user(client).is_authenticated is True
+    logout_params = {"id_token_hint": id_token}
+
+    logout_client = Client() if other_client else client
+    logout_method = getattr(logout_client, method)
+
+    response = logout_method(add_url_params(reverse("oidc_overrides:logout"), logout_params))
+    assertRedirects(response, "http://testserver/", fetch_redirect_response=False)
+
+    assert get_user(logout_client).is_authenticated is False
+    assert get_user(client).is_authenticated is False
+    assert has_ongoing_sessions(user) is False
+    assert token_are_revoked(user) is True
+
+
+@pytest.mark.parametrize(
+    "method,other_client",
+    [("get", True), ("get", False), ("post", True), ("post", False)],
+)
+def test_logout_expired_token(client, method, other_client):
+    """This test simulates a GET or POST on logout endpoint from RP backend or the user browser"""
+    user = UserFactory()
+    with freeze_time("2023-05-05 14:29:20"):
+        id_token = oidc_complete_flow(client, user)
+        assert get_user(client).is_authenticated is True
+
+    logout_params = {"id_token_hint": id_token}
+
+    logout_client = Client() if other_client else client
+    logout_method = getattr(logout_client, method)
+
+    with freeze_time("2023-05-05 14:59:21"):
+        response = logout_method(add_url_params(reverse("oidc_overrides:logout"), logout_params))
+        assertRedirects(response, "http://testserver/", fetch_redirect_response=False)
+
+        assert get_user(client).is_authenticated is False
+        assert has_ongoing_sessions(user) is False
+        assert token_are_revoked(user) is True
+
+
+@pytest.mark.parametrize(
+    "method,other_client",
+    [("get", True), ("get", False), ("post", True), ("post", False)],
+)
+def test_logout_bad_login_hint(client, method, other_client):
+    """This test simulates a GET or POST on logout endpoint from RP backend or the user browser"""
+    user = UserFactory()
+    oidc_complete_flow(client, user)
 
     assert get_user(client).is_authenticated is True
     logout_params = {"id_token_hint": 111}  # bad token
-    # TODO: also try with existing token but expired
-    response = client.get(add_url_params(reverse("oidc_overrides:logout"), logout_params))
+
+    logout_client = Client() if other_client else client
+    logout_method = getattr(logout_client, method)
+
+    response = logout_method(add_url_params(reverse("oidc_overrides:logout"), logout_params))
     assertRedirects(response, "http://testserver/", fetch_redirect_response=False)
-    assert not get_user(client).is_authenticated
+
+    assert get_user(logout_client).is_authenticated is False
+    assert token_are_revoked(user) is False
+
+    if other_client:  # Django original session was not deleted as we couldn't match a user
+        assert get_user(client).is_authenticated is True
+        assert has_ongoing_sessions(user) is True
+    else:
+        assert get_user(client).is_authenticated is False
+        assert has_ongoing_sessions(user) is False
 
 
 def test_authorize_bad_oidc_params(client):

--- a/inclusion_connect/oidc_overrides/views.py
+++ b/inclusion_connect/oidc_overrides/views.py
@@ -105,7 +105,7 @@ class LogoutView(View):
             # FIXME: replicate the issue in a test ?
             [
                 s.delete()
-                for s in Session.objects.all()
+                for s in Session.objects.filter(expiry_date__gte=timezone.now())
                 if s.get_decoded().get("_auth_user_id") == str(id_token.user_id)
             ]
         except Exception:

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -300,6 +300,7 @@ OAUTH2_PROVIDER = {
     },
     "PKCE_REQUIRED": False,
     "OAUTH2_VALIDATOR_CLASS": "inclusion_connect.oidc_overrides.validators.CustomOAuth2Validator",
+    "REFRESH_TOKEN_EXPIRE_SECONDS": SESSION_COOKIE_AGE,
 }
 
 OAUTH2_PROVIDER_APPLICATION_MODEL = "oidc_overrides.Application"

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -186,13 +186,8 @@ SESSION_COOKIE_NAME = "INCLUSION_CONNECT"
 # Force browser to end session when closing.
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
-# Since some browser restore session when restarting, the previous setting may not
-# work as we want. This is why we ask Django to expire sessions in DB after 1 week
-# of inactivity.
-# -> https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_the_lifetime_of_a_cookie
-# In addition, the command shorten_active_sessions is run every week to force user to connect at least once per week
-# FIXME
-SESSION_COOKIE_AGE = 60 * 60 * 24 * 7
+# Set django session ligespan to 30 minutes
+SESSION_COOKIE_AGE = 60 * 30
 
 X_FRAME_OPTIONS = "DENY"
 

--- a/inclusion_connect/test.py
+++ b/inclusion_connect/test.py
@@ -1,0 +1,97 @@
+import uuid
+
+import jwt
+from django.contrib.sessions.models import Session
+from django.urls import reverse
+from django.utils import timezone
+from oauth2_provider.models import get_access_token_model, get_id_token_model, get_refresh_token_model
+
+from inclusion_connect.oidc_overrides.factories import DEFAULT_CLIENT_SECRET, ApplicationFactory, default_client_secret
+from inclusion_connect.users.factories import DEFAULT_PASSWORD
+from inclusion_connect.utils.urls import add_url_params, get_url_params
+
+
+OIDC_PARAMS = {
+    "response_type": "code",
+    "client_id": "my_application",
+    "redirect_uri": "http://localhost/callback",
+    "scope": "openid profile email",
+    "state": "state",
+    "nonce": "nonce",
+}
+
+
+def oidc_flow_followup(client, auth_response_params, user):
+    # Call TOKEN endpoint
+    # FIXME it's recommanded to use basic auth here, maybe update our documentation ?
+    token_data = {
+        "client_id": OIDC_PARAMS["client_id"],
+        "client_secret": DEFAULT_CLIENT_SECRET,
+        "code": auth_response_params["code"],
+        "grant_type": "authorization_code",
+        "redirect_uri": OIDC_PARAMS["redirect_uri"],
+    }
+    response = client.post(reverse("oauth2_provider:token"), data=token_data)
+
+    token_json = response.json()
+    id_token = token_json["id_token"]
+    decoded_id_token = jwt.decode(
+        id_token,
+        key=default_client_secret(),
+        algorithms=["HS256"],
+        audience=OIDC_PARAMS["client_id"],
+    )
+    assert decoded_id_token["nonce"] == OIDC_PARAMS["nonce"]
+    assert decoded_id_token["sub"] == str(user.pk)
+    assert uuid.UUID(decoded_id_token["sub"]), "Sub should be an uuid"
+    assert decoded_id_token["given_name"] == user.first_name
+    assert decoded_id_token["family_name"] == user.last_name
+    assert decoded_id_token["email"] == user.email
+
+    # Call USER INFO endpoint
+    response = client.get(
+        reverse("oauth2_provider:user-info"),
+        HTTP_AUTHORIZATION=f"Bearer {token_json['access_token']}",
+    )
+    assert response.json() == {
+        "sub": str(user.pk),
+        "given_name": user.first_name,
+        "family_name": user.last_name,
+        "email": user.email,
+    }
+
+    return token_json["id_token"]
+
+
+def oidc_complete_flow(client, user):
+    ApplicationFactory(client_id=OIDC_PARAMS["client_id"])
+    auth_url = reverse("oidc_overrides:authorize")
+    auth_complete_url = add_url_params(auth_url, OIDC_PARAMS)
+    response = client.get(auth_complete_url)
+    response = client.post(
+        response.url,
+        data={
+            "email": user.email,
+            "password": DEFAULT_PASSWORD,
+        },
+    )
+    response = client.get(response.url)
+    auth_response_params = get_url_params(response.url)
+    return oidc_flow_followup(client, auth_response_params, user)
+
+
+def has_ongoing_sessions(user):
+    ongoing_sessions = [
+        s
+        for s in Session.objects.filter(expire_date__gte=timezone.now())
+        if s.get_decoded().get("_auth_user_id") == str(user.pk)
+    ]
+    return bool(ongoing_sessions)
+
+
+def token_are_revoked(user):
+    return (
+        not get_id_token_model().objects.filter(user=user).exists()
+        and not get_access_token_model().objects.filter(user=user).exists()
+        and get_refresh_token_model().objects.get().revoked is not None
+    )


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Refonte-G-rer-la-dur-e-de-session-Django-0977be5cc91c4f46b8dbb58bedae1d1d?pvs=4

### Pourquoi ?

Comme la durée de session est ré-initialisée à chaque tentative de connexion (mécanisme par défaut de Django), une session de 15 jours ne s'arrêterait sans doute jamais.

On verra si on décide d'augmenter la durée à quelques heures
