### PR TITLE
Gestion des actions post login (nouvelles CGUs)

### DIFF
--- a/inclusion_connect/accounts/urls.py
+++ b/inclusion_connect/accounts/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     re_path(r"^activate/$", views.ActivateAccountView.as_view(), name="activate"),
     re_path(r"^password_reset/$", views.PasswordResetView.as_view(), name="password_reset"),
     path("reset/<uidb64>/<token>/", views.PasswordResetConfirmView.as_view(), name="password_reset_confirm"),
+    re_path(r"^accept-terms/$", views.AcceptTermsView.as_view(), name="accept_terms"),
     re_path(r"^my-account/$", views.EditUserInfoView.as_view(), name="edit_user_info"),
     re_path(r"^change-password/$", views.PasswordChangeView.as_view(), name="change_password"),
 ]

--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -4,7 +4,8 @@ from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
-from django.views.generic import CreateView, FormView, UpdateView
+from django.utils import timezone
+from django.views.generic import CreateView, FormView, TemplateView, UpdateView
 
 from inclusion_connect.accounts import forms
 from inclusion_connect.oidc_overrides.views import OIDCSessionMixin
@@ -97,6 +98,15 @@ class PasswordResetConfirmView(OIDCSessionMixin, auth_views.PasswordResetConfirm
     template_name = "password_reset_confirm.html"
     form_class = forms.SetPasswordForm
     post_reset_login = True
+
+
+class AcceptTermsView(LoginRequiredMixin, OIDCSessionMixin, TemplateView):
+    template_name = "accept_terms.html"
+
+    def post(self, *args, **kwargs):
+        self.request.user.terms_accepted_at = timezone.now()
+        self.request.user.save()
+        return HttpResponseRedirect(self.get_success_url())
 
 
 class MyAccountMixin(LoginRequiredMixin):

--- a/inclusion_connect/oidc_overrides/views.py
+++ b/inclusion_connect/oidc_overrides/views.py
@@ -34,6 +34,12 @@ class OIDCSessionMixin:
         return self.request.session.get("next_url") or reverse("accounts:edit_user_info")
 
     def get_success_url(self):
+        # FIXME: Maybe we should move everything except the session saving into accounts app ?
+        user = getattr(self, "object", self.request.user)  # in CreateView, user is stored in self.object
+        # TODO: if user email is not validated -> redirect to email validation view
+        if user.must_accept_terms:
+            return reverse("accounts:accept_terms")
+        # TODO: if user password is temporary, redirect to password change view
         return self.get_next_url()
 
     def setup(self, request, *args, **kwargs):

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
+import datetime
 import os
 from pathlib import Path
 
@@ -272,6 +273,9 @@ if SENTRY_DSN:
     from ._sentry import sentry_init
 
     sentry_init(dsn=SENTRY_DSN, traces_sample_rate=_sentry_traces_sample_rate)
+
+new_terms_date_str = os.getenv("NEW_TERMS_DATE", "2023-03-02T00:00:00+00:00")
+NEW_TERMS_DATE = datetime.datetime.fromisoformat(new_terms_date_str)
 
 # Email
 # -----

--- a/inclusion_connect/templates/accept_terms.html
+++ b/inclusion_connect/templates/accept_terms.html
@@ -1,0 +1,33 @@
+{% extends "layout/left_content.html" %}
+{% load bootstrap4 %}
+{% load inclusionconnect_fields %}
+{% load static %}
+
+{% block content %}
+
+    <h1 class="fr-h4">Conditions d’utilisation et confidentialité</h1>
+
+    <div>
+        <p>
+            Pour utiliser votre compte Inclusion Connect, vous devez accepter les conditions générales d’utilisation du service ainsi que la politique de confidentialité.
+        </p>
+
+        <ul>
+            <li>
+                <a href="{% static "terms/CGU_20230302.pdf" %}" target="_blank">Conditions générales d’utilisation</a>
+            </li>
+            <li>
+                <a href="{% static "terms/Politique de confidentialité_20230302.pdf" %}" target="_blank">
+                    Politique de confidentialité
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    <form method="post" class="js-prevent-multiple-submit">
+        {% csrf_token %}
+        <div>{% bootstrap_button "Accepter" button_type="submit" button_class="btn btn-block btn-primary" %}</div>
+    </form>
+
+
+{% endblock %}

--- a/inclusion_connect/users/models.py
+++ b/inclusion_connect/users/models.py
@@ -36,6 +36,10 @@ class User(AbstractUser):
         # Required by some third party libraries that use user.id (django-oauth-toolkit)
         return self.pk
 
+    @property
+    def must_accept_terms(self):
+        return self.terms_accepted_at is None or self.terms_accepted_at < settings.NEW_TERMS_DATE
+
 
 class UserApplicationLink(models.Model):
     user = models.ForeignKey(

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -2,6 +2,7 @@ import functools
 
 import factory
 from django.contrib.auth.hashers import make_password
+from django.utils import timezone
 
 from inclusion_connect.users.models import User
 
@@ -24,3 +25,4 @@ class UserFactory(factory.django.DjangoModelFactory):
     last_name = factory.Faker("last_name")
     email = factory.Sequence("email{}@domain.com".format)
     password = factory.LazyFunction(default_password)
+    terms_accepted_at = factory.LazyFunction(timezone.now)


### PR DESCRIPTION
https://www.notion.so/plateforme-inclusion/Refonte-Gestion-de-nouvelles-CGUs-77e9b7315b2549d38bae0a5c03be2857?pvs=4

### Pourquoi ?

Gérer la redirection vers l'acceptation de nouvelles CGUs , la ré-initialisation de mot de passe ou la vérification d'adresse e-mail au besoin.

Seul le dernier commit est à relire
