### PR TITLE
Correction de la casse de caractère pour “Se connecter”

### DIFF
--- a/inclusion_connect/accounts/forms.py
+++ b/inclusion_connect/accounts/forms.py
@@ -68,7 +68,7 @@ class RegistrationForm(auth_forms.UserCreationForm):
         if User.objects.filter(email=email).exists():
             raise ValidationError(
                 format_html(
-                    'Un compte avec cette adresse e-mail existe déjà, <a href="{}">Se connecter</a> ?',
+                    'Un compte avec cette adresse e-mail existe déjà, <a href="{}">se connecter</a> ?',
                     reverse("accounts:login"),
                 )
             )

--- a/inclusion_connect/accounts/tests.py
+++ b/inclusion_connect/accounts/tests.py
@@ -107,7 +107,7 @@ def test_user_creation_fails_email_exists(client):
     assertContains(
         response,
         format_html(
-            'Un compte avec cette adresse e-mail existe déjà, <a href="{}">Se connecter</a> ?',
+            'Un compte avec cette adresse e-mail existe déjà, <a href="{}">se connecter</a> ?',
             reverse("accounts:login"),
         ),
         html=True,


### PR DESCRIPTION
On est au milieu d’une phrase, pas besoin de majuscule.