### PR TITLE
Correction de l'erreur d'activation quand l'email existe déjà

### DIFF
--- a/inclusion_connect/accounts/forms.py
+++ b/inclusion_connect/accounts/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib.auth import authenticate, forms as auth_forms
 from django.core.exceptions import ValidationError
 from django.forms import HiddenInput
+from django.forms.forms import NON_FIELD_ERRORS
 from django.templatetags.static import static
 from django.urls import reverse
 from django.utils.html import format_html
@@ -80,6 +81,12 @@ class RegisterForm(auth_forms.UserCreationForm):
             self.fields[key].widget.attrs["placeholder"] = PASSWORD_PLACEHOLDER
 
         self.fields["email"].widget.attrs = EMAIL_FIELDS_WIDGET_ATTRS
+
+    def clean(self):
+        if "email" in self.errors:
+            self.errors.setdefault(NON_FIELD_ERRORS, [])
+            self.errors[NON_FIELD_ERRORS] += self.errors["email"]
+        return super().clean()
 
     def save(self, commit=True):
         self.instance.terms_accepted_at = self.instance.date_joined

--- a/inclusion_connect/templates/activate_account.html
+++ b/inclusion_connect/templates/activate_account.html
@@ -12,7 +12,6 @@
 
     <hr>
 
-    {{ last_name }} {{ first_name }} ({{ email }})
 
     <form method="post" class="js-prevent-multiple-submit">
         {% csrf_token %}
@@ -20,6 +19,7 @@
             <div class="row">
                 <div class="col-12">
                     {% bootstrap_form_errors form type="all" %}
+                    <p>{{ last_name }} {{ first_name }} ({{ email }})</p>
                     {% bootstrap_field form.last_name %}
                     {% bootstrap_field form.first_name %}
                     {% bootstrap_field form.email %}


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Refonte-G-rer-les-erreurs-d-activation-afb976fa3afa4576b60f3c4186f60e4a?pvs=4

### Pourquoi ?

Actuellement aucune erreur n'est affichée car elle est liée à un champ caché
