### PR TITLE
Améliorer le template d'erreur OpenID Connect

### DIFF
--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -1,7 +1,8 @@
 from django.contrib import messages
 from django.contrib.auth import login, views as auth_views
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponseBadRequest, HttpResponseRedirect
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
 from django.urls import reverse
 from django.views.generic import CreateView, FormView, UpdateView
 
@@ -45,10 +46,15 @@ class ActivateAccountView(BaseUserCreationView):
         try:
             self.get_user_info()
         except KeyError:
-            return HttpResponseBadRequest()
+            return render(
+                request,
+                "oidc_authorize.html",
+                {"error": {"error": "invalid_request", "description": "Missing activation parameters"}},
+                status=400,
+            )
         return super().dispatch(request, *args, **kwargs)
 
-    def get_user_info(self, raise_exception=False):
+    def get_user_info(self):
         params = self.get_oidc_params()
 
         # TODO: Remove keycloak compatibility

--- a/inclusion_connect/oidc_overrides/views.py
+++ b/inclusion_connect/oidc_overrides/views.py
@@ -53,6 +53,8 @@ class BaseAuthorizationView(OIDCSessionMixin, oauth2_views.base.AuthorizationVie
     the registration pages
     """
 
+    template_name = "oidc_authorize.html"
+
     def dispatch(self, request, *args, **kwargs):
         try:
             self.validate_authorization_request(request)

--- a/inclusion_connect/templates/oidc_authorize.html
+++ b/inclusion_connect/templates/oidc_authorize.html
@@ -1,0 +1,36 @@
+{% extends "layout/left_content.html" %}
+
+{% block content %}
+    <div class="block-center">
+        {% if not error %}
+            {# We should never get here because we always set skip_authorization to True #}
+            <form id="authorizationForm" method="post">
+                <h3 class="block-center-heading">Autoriser {{ application.name }} ?</h3>
+                {% csrf_token %}
+
+                {% for field in form %}
+                    {% if field.is_hidden %}{{ field }}{% endif %}
+                {% endfor %}
+
+                <p>L'application nécessite les permissiopns suivantes</p>
+                <ul>
+                    {% for scope in scopes_descriptions %}<li>{{ scope }}</li>{% endfor %}
+                </ul>
+
+                {{ form.errors }}
+                {{ form.non_field_errors }}
+
+                <div class="control-group">
+                    <div class="controls">
+                        <input type="submit" class="btn btn-large" value="Annuler" />
+                        <input type="submit" class="btn btn-large btn-primary" name="allow" value="Autoriser" />
+                    </div>
+                </div>
+            </form>
+
+        {% else %}
+            <h2>Error: {{ error.error }}</h2>
+            <p>{{ error.description }}</p>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/tests/keycloak_compat/tests.py
+++ b/tests/keycloak_compat/tests.py
@@ -39,7 +39,6 @@ def test_login(client, realm):
     bad_auth_params["client_id"] = "toto"
     bad_auth_complete_url = add_url_params(auth_url, bad_auth_params)
     response = client.get(bad_auth_complete_url)
-    # FIXME update the template
     assert response.status_code == 400
 
     # Test AUTH endpoint when authenticated
@@ -122,7 +121,6 @@ def test_registration(client, realm):
     bad_auth_params["client_id"] = "toto"
     bad_auth_complete_url = add_url_params(auth_url, bad_auth_params)
     response = client.get(bad_auth_complete_url)
-    # FIXME update the template
     assert response.status_code == 400
 
     # Test REGISTRATIONS endpoint when not authenticated with activation params

--- a/tests/oidc_overrides/__snapshots__/tests.ambr
+++ b/tests/oidc_overrides/__snapshots__/tests.ambr
@@ -1,0 +1,169 @@
+# serializer version: 1
+# name: test_activation_bad_oidc_params
+  '''
+  <main class="s-main" id="main" role="main">
+  
+              <section class="s-section pt-lg-3">
+                  <div class="s-section__container container">
+                      <div class="s-section__row row no-gutters bg-white">
+                          
+      <div class="s-section__col col-12 col-lg-6 bg-lg-white">
+          <div class="bg-white p-3 py-lg-7 px-lg-8">
+              <div class="container container-messages">
+                  
+                      
+  
+  
+                  
+              </div>
+  
+              
+      <div class="block-center">
+          
+              <h2>Error: invalid_request</h2>
+              <p>Invalid client_id parameter value.</p>
+          
+      </div>
+  
+          </div>
+      </div>
+  
+                          
+      <div class="s-section__col d-none d-lg-flex col-lg-6 p-lg-6 justify-content-center align-items-center bg-light">
+          <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-ic.svg"/>
+      </div>
+  
+                      </div>
+                  </div>
+              </section>
+  
+  
+          </main>
+  '''
+# ---
+# name: test_activation_missing_user_info
+  '''
+  <main class="s-main" id="main" role="main">
+  
+              <section class="s-section pt-lg-3">
+                  <div class="s-section__container container">
+                      <div class="s-section__row row no-gutters bg-white">
+                          
+      <div class="s-section__col col-12 col-lg-6 bg-lg-white">
+          <div class="bg-white p-3 py-lg-7 px-lg-8">
+              <div class="container container-messages">
+                  
+                      
+  
+  
+                  
+              </div>
+  
+              
+      <div class="block-center">
+          
+              <h2>Error: invalid_request</h2>
+              <p>Missing activation parameters</p>
+          
+      </div>
+  
+          </div>
+      </div>
+  
+                          
+      <div class="s-section__col d-none d-lg-flex col-lg-6 p-lg-6 justify-content-center align-items-center bg-light">
+          <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-ic.svg"/>
+      </div>
+  
+                      </div>
+                  </div>
+              </section>
+  
+  
+          </main>
+  '''
+# ---
+# name: test_authorize_bad_oidc_params
+  '''
+  <main class="s-main" id="main" role="main">
+  
+              <section class="s-section pt-lg-3">
+                  <div class="s-section__container container">
+                      <div class="s-section__row row no-gutters bg-white">
+                          
+      <div class="s-section__col col-12 col-lg-6 bg-lg-white">
+          <div class="bg-white p-3 py-lg-7 px-lg-8">
+              <div class="container container-messages">
+                  
+                      
+  
+  
+                  
+              </div>
+  
+              
+      <div class="block-center">
+          
+              <h2>Error: invalid_request</h2>
+              <p>Invalid client_id parameter value.</p>
+          
+      </div>
+  
+          </div>
+      </div>
+  
+                          
+      <div class="s-section__col d-none d-lg-flex col-lg-6 p-lg-6 justify-content-center align-items-center bg-light">
+          <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-ic.svg"/>
+      </div>
+  
+                      </div>
+                  </div>
+              </section>
+  
+  
+          </main>
+  '''
+# ---
+# name: test_registrations_bad_oidc_params
+  '''
+  <main class="s-main" id="main" role="main">
+  
+              <section class="s-section pt-lg-3">
+                  <div class="s-section__container container">
+                      <div class="s-section__row row no-gutters bg-white">
+                          
+      <div class="s-section__col col-12 col-lg-6 bg-lg-white">
+          <div class="bg-white p-3 py-lg-7 px-lg-8">
+              <div class="container container-messages">
+                  
+                      
+  
+  
+                  
+              </div>
+  
+              
+      <div class="block-center">
+          
+              <h2>Error: invalid_request</h2>
+              <p>Invalid client_id parameter value.</p>
+          
+      </div>
+  
+          </div>
+      </div>
+  
+                          
+      <div class="s-section__col d-none d-lg-flex col-lg-6 p-lg-6 justify-content-center align-items-center bg-light">
+          <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-ic.svg"/>
+      </div>
+  
+                      </div>
+                  </div>
+              </section>
+  
+  
+          </main>
+  '''
+# ---


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Refonte-Ajouter-un-joli-template-param-tres-OIDC-incorrects-19d930e6338a4eb889bc68295ac644a0?pvs=4

### Pourquoi ?

Pour avoir la même apparence que les autres pages


### Captures d'écran <!-- optionnel -->

Voir carte notion