### PR TITLE
Ajouter `assertMessages`

### DIFF
--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -17,6 +17,7 @@ from inclusion_connect.accounts.views import PasswordResetView
 from inclusion_connect.oidc_overrides.views import OIDCSessionMixin
 from inclusion_connect.users.models import User
 from inclusion_connect.utils.urls import add_url_params
+from tests.asserts import assertMessages
 from tests.users.factories import DEFAULT_PASSWORD, UserFactory
 
 
@@ -276,13 +277,16 @@ def test_password_reset(client):
 
     response = client.post(password_reset_url, data={"email": user.email})
     assertRedirects(response, reverse("accounts:login"))
-    assert list(messages.get_messages(response.wsgi_request)) == [
-        messages.storage.base.Message(
-            messages.SUCCESS,
-            "Si un compte existe avec cette adresse e-mail, "
-            "vous recevrez un e-mail contenant des instructions pour réinitialiser votre mot de passe.",
-        ),
-    ]
+    assertMessages(
+        response,
+        [
+            (
+                messages.SUCCESS,
+                "Si un compte existe avec cette adresse e-mail, "
+                "vous recevrez un e-mail contenant des instructions pour réinitialiser votre mot de passe.",
+            ),
+        ],
+    )
 
     # Check sent email
     assert len(mail.outbox) == 1

--- a/tests/asserts.py
+++ b/tests/asserts.py
@@ -1,0 +1,20 @@
+from typing import List, NamedTuple
+
+from django.contrib.messages import DEFAULT_LEVELS, get_messages
+from django.http import HttpResponse
+
+
+class Message(NamedTuple):
+    level: int
+    message: str
+
+
+LEVEL_TO_NAME = {intlevel: name for name, intlevel in DEFAULT_LEVELS.items()}
+
+
+def assertMessages(response: HttpResponse, expected_messages: List[Message]):
+    request_messages = get_messages(response.wsgi_request)
+    for message, (expected_level, expected_msg) in zip(request_messages, expected_messages):
+        msg_levelname = LEVEL_TO_NAME.get(message.level, message.level)
+        expected_levelname = LEVEL_TO_NAME.get(expected_level, expected_level)
+        assert (msg_levelname, message.message) == (expected_levelname, expected_msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 
 
+pytest.register_assert_rewrite("tests.asserts")
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
     """Automatically add pytest db marker if needed."""

--- a/tests/tests_functional.py
+++ b/tests/tests_functional.py
@@ -10,6 +10,7 @@ from pytest_django.asserts import assertContains, assertRedirects
 
 from inclusion_connect.users.models import User
 from inclusion_connect.utils.urls import add_url_params, get_url_params
+from tests.asserts import assertMessages
 from tests.helpers import OIDC_PARAMS, oidc_flow_followup, token_are_revoked
 from tests.oidc_overrides.factories import ApplicationFactory
 from tests.users.factories import DEFAULT_PASSWORD, UserFactory
@@ -134,13 +135,16 @@ def test_login_after_password_reset(client):
     response = client.post(reverse("accounts:password_reset"), data={"email": user.email})
     assertRedirects(response, reverse("accounts:login"))
 
-    assert list(messages.get_messages(response.wsgi_request)) == [
-        messages.storage.base.Message(
-            messages.SUCCESS,
-            "Si un compte existe avec cette adresse e-mail, "
-            "vous recevrez un e-mail contenant des instructions pour réinitialiser votre mot de passe.",
-        ),
-    ]
+    assertMessages(
+        response,
+        [
+            (
+                messages.SUCCESS,
+                "Si un compte existe avec cette adresse e-mail, "
+                "vous recevrez un e-mail contenant des instructions pour réinitialiser votre mot de passe.",
+            )
+        ],
+    )
 
     reset_url_regex = reverse("accounts:password_reset_confirm", args=("string", "string")).replace("string", "[^/]*")
     reset_url = re.search(reset_url_regex, mail.outbox[0].body)[0]


### PR DESCRIPTION
### Pourquoi ?

Évite de répéter une danse bizarre pour avoir les messages affichés suite à une réponse.