### PR TITLE
Do not repeat error messages on top of forms

### DIFF
--- a/inclusion_connect/templates/activate_account.html
+++ b/inclusion_connect/templates/activate_account.html
@@ -18,7 +18,7 @@
         <fieldset>
             <div class="row">
                 <div class="col-12">
-                    {% bootstrap_form_errors form type="all" %}
+                    {% bootstrap_form_errors form type="non_fields" %}
                     <p>{{ last_name }} {{ first_name }} ({{ email }})</p>
                     {% bootstrap_field form.last_name %}
                     {% bootstrap_field form.first_name %}

--- a/inclusion_connect/templates/change_password.html
+++ b/inclusion_connect/templates/change_password.html
@@ -10,7 +10,7 @@
         <fieldset>
             <div class="row">
                 <div class="col-12">
-                    {% bootstrap_form_errors form type="all" %}
+                    {% bootstrap_form_errors form type="non_fields" %}
                     {% password_field form.old_password %}
                     {% password_field form.new_password1 %}
                     {% password_field form.new_password2 %}

--- a/inclusion_connect/templates/edit_user_info.html
+++ b/inclusion_connect/templates/edit_user_info.html
@@ -8,7 +8,7 @@
         {% csrf_token %}
         <fieldset>
             <div class="row">
-                <div class="col-12">{% bootstrap_form form alert_error_type="all" %}</div>
+                <div class="col-12">{% bootstrap_form form %}</div>
             </div>
         </fieldset>
         <div>

--- a/inclusion_connect/templates/login.html
+++ b/inclusion_connect/templates/login.html
@@ -11,7 +11,7 @@
         <fieldset>
             <div class="row">
                 <div class="col-12">
-                    {% bootstrap_form_errors form type="all" %}
+                    {% bootstrap_form_errors form type="non_fields" %}
                     {% bootstrap_field form.email %}
                     {% password_field form.password %}
                     <div class="form-group">

--- a/inclusion_connect/templates/password_reset.html
+++ b/inclusion_connect/templates/password_reset.html
@@ -13,7 +13,7 @@
         {% csrf_token %}
         <fieldset>
             <div class="row">
-                <div class="col-12">{% bootstrap_form form alert_error_type="all" %}</div>
+                <div class="col-12">{% bootstrap_form form %}</div>
             </div>
         </fieldset>
         <div>{% bootstrap_button "Soumettre" button_type="submit" button_class="btn btn-block btn-primary" %}</div>

--- a/inclusion_connect/templates/password_reset_confirm.html
+++ b/inclusion_connect/templates/password_reset_confirm.html
@@ -14,7 +14,7 @@
             <fieldset>
                 <div class="row">
                     <div class="col-12">
-                        {% bootstrap_form_errors form type="all" %}
+                        {% bootstrap_form_errors form type="non_fields" %}
                         {% password_field form.new_password1 %}
                         {% password_field form.new_password2 %}
                     </div>

--- a/inclusion_connect/templates/register.html
+++ b/inclusion_connect/templates/register.html
@@ -15,7 +15,7 @@
         <fieldset>
             <div class="row">
                 <div class="col-12">
-                    {% bootstrap_form_errors form type="all" %}
+                    {% bootstrap_form_errors form type="non_fields" %}
                     {% bootstrap_field form.last_name %}
                     {% bootstrap_field form.first_name %}
                     {% bootstrap_field form.email %}

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -237,7 +237,7 @@ def test_user_creation_email_already_exists_and_not_verified(client):
     login_url = reverse("accounts:login")
     msg = f'Un compte avec cette adresse e-mail existe déjà, <a href="{login_url}">se connecter</a> ?'
     # Displayed in bootstrap_form_errors type="all" and next to the field.
-    assertContains(response, msg, count=2)
+    assertContains(response, msg, count=1)
 
 
 def test_user_creation_terms_are_required(client, mailoutbox):


### PR DESCRIPTION
The errors are given next to their fields. Repeating them above the
forms isn’t as helpful, and gets unwieldy when there are multiple
errors.