### PR TITLE
Add the never cache middleware

### DIFF
--- a/inclusion_connect/middleware.py
+++ b/inclusion_connect/middleware.py
@@ -1,0 +1,11 @@
+from django.utils.cache import add_never_cache_headers
+
+
+def never_cache(get_response):
+    def middleware(request):
+        response = get_response(request)
+        if request.user.is_authenticated:
+            add_never_cache_headers(response)
+        return response
+
+    return middleware

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -70,6 +70,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "inclusion_connect.middleware.never_cache",
 ]
 
 ROOT_URLCONF = "inclusion_connect.urls"


### PR DESCRIPTION
Avoids sometimes confusing behavior when pressing the “Back” button in
the browser.

Example STR this is guarding against:

1. Edit user info with a new email (not verified)
2. Submit the form, get redirected to the email confirmation page
3. Hit the browser back button

Notice the email is the new, unverified, email (that was submitted). Do
a reload without cache, notice the email is the old, verified, email.