### PR TITLE
Correctly specify <input type="email">

### DIFF
--- a/inclusion_connect/accounts/forms.py
+++ b/inclusion_connect/accounts/forms.py
@@ -10,14 +10,14 @@ from inclusion_connect.accounts.emails import send_verification_email
 from inclusion_connect.users.models import EmailAddress, User
 
 
-EMAIL_FIELDS_WIDGET_ATTRS = {"type": "email", "placeholder": "nom@domaine.fr", "autocomplete": "email"}
+EMAIL_FIELDS_WIDGET_ATTRS = {"placeholder": "nom@domaine.fr", "autocomplete": "email"}
 PASSWORD_PLACEHOLDER = "**********"
 
 
 class LoginForm(forms.Form):
     email = forms.EmailField(
         label="Adresse e-mail",
-        widget=forms.TextInput(attrs=EMAIL_FIELDS_WIDGET_ATTRS),
+        widget=forms.EmailInput(attrs=EMAIL_FIELDS_WIDGET_ATTRS),
     )
     password = forms.CharField(
         label="Mot de passe",

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -454,7 +454,7 @@ class TestEditUserInfoView:
         assertNotContains(response, return_text)
         assertContains(
             response,
-            f'<input type="email" name="email" value="{user.email}" type="email" placeholder="nom@domaine.fr" '
+            f'<input type="email" name="email" value="{user.email}" placeholder="nom@domaine.fr" '
             'autocomplete="email" class="form-control" title="" required id="id_email">',
             count=1,
         )


### PR DESCRIPTION
The `EmailInput` widget already specifies `type="email"`, resulting in
the attribute being present twice in the HTML. The
EMAIL_FIELDS_WIDGET_ATTRS seems to have specified `type="email"` because
it was using a `TextInput` and not an `EmailInput`.