### PR TITLE
Increase tests verbosity on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ populate_db:
 .PHONY: coverage test
 
 test: $(VIRTUAL_ENV)
-	pytest --numprocesses=logical --create-db $(TARGET)
+	pytest --numprocesses=logical --create-db --verbosity=2 $(TARGET)
 
 coverage: $(VIRTUAL_ENV)
 	coverage run -m pytest


### PR DESCRIPTION
Gives more helpful failure messages instead of putting ellipsis, and
lists the tests that ran, facilitating the comparison with other test
runs (previous builds, local output).