### PR TITLE
Rename {get_user_next_action_url,required_action_url}

### DIFF
--- a/inclusion_connect/accounts/middleware.py
+++ b/inclusion_connect/accounts/middleware.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 
 
-def get_user_next_action_url(user):
+def required_action_url(user):
     if user.must_accept_terms:
         return reverse("accounts:accept_terms")
     if user.must_reset_password:
@@ -22,7 +22,7 @@ def post_login_actions(get_response):
         path_is_whitelisted = request.path in whitelisted_urls
 
         if user.is_authenticated and user.is_staff is False and path_is_whitelisted is False:
-            next_action_url = get_user_next_action_url(user)
+            next_action_url = required_action_url(user)
             if next_action_url and not request.path == next_action_url:
                 return HttpResponseRedirect(next_action_url)
 

--- a/inclusion_connect/oidc_overrides/views.py
+++ b/inclusion_connect/oidc_overrides/views.py
@@ -13,7 +13,7 @@ from oauth2_provider.http import OAuth2ResponseRedirect
 from oauth2_provider.models import get_access_token_model, get_id_token_model, get_refresh_token_model
 from oauth2_provider.settings import oauth2_settings
 
-from inclusion_connect.accounts.middleware import get_user_next_action_url
+from inclusion_connect.accounts.middleware import required_action_url
 from inclusion_connect.oidc_overrides.models import Application
 from inclusion_connect.oidc_overrides.validators import CustomOAuth2Validator
 from inclusion_connect.users.models import User, UserApplicationLink
@@ -36,7 +36,7 @@ class OIDCSessionMixin:
 
     def get_success_url(self):
         user = getattr(self, "object", self.request.user)  # in CreateView, user is stored in self.object
-        return get_user_next_action_url(user) or self.get_next_url()
+        return required_action_url(user) or self.get_next_url()
 
     def setup(self, request, *args, **kwargs):
         next_url = request.GET.get("next")


### PR DESCRIPTION
Clarify why the `next_action_url` has precedence over the `next_url`.