### PR TITLE
Clean handling of `next_url`

### DIFF
--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -108,13 +108,16 @@ class PasswordResetView(auth_views.PasswordResetView):
         return reverse("accounts:login")
 
 
-class PasswordResetConfirmView(OIDCSessionMixin, auth_views.PasswordResetConfirmView):
+class PasswordResetConfirmView(auth_views.PasswordResetConfirmView):
     template_name = "password_reset_confirm.html"
     form_class = forms.SetPasswordForm
     post_reset_login = True
 
+    def get_success_url(self):
+        return get_next_url(self.request)
 
-class AcceptTermsView(LoginRequiredMixin, OIDCSessionMixin, TemplateView):
+
+class AcceptTermsView(LoginRequiredMixin, TemplateView):
     template_name = "accept_terms.html"
 
     def post(self, request, *args, **kwargs):
@@ -180,7 +183,7 @@ class ConfirmEmailTokenView(View):
         return HttpResponseRedirect(get_next_url(request))
 
 
-class ChangeTemporaryPassword(LoginRequiredMixin, OIDCSessionMixin, FormView):
+class ChangeTemporaryPassword(LoginRequiredMixin, FormView):
     template_name = "password_reset_confirm.html"
     form_class = forms.SetPasswordForm
 
@@ -189,6 +192,9 @@ class ChangeTemporaryPassword(LoginRequiredMixin, OIDCSessionMixin, FormView):
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {"validlink": True}
+
+    def get_success_url(self):
+        return get_next_url(self.request)
 
     def form_valid(self, form):
         user = form.save()

--- a/inclusion_connect/keycloak_compat/views.py
+++ b/inclusion_connect/keycloak_compat/views.py
@@ -10,11 +10,11 @@ from inclusion_connect.accounts.helpers import login
 from inclusion_connect.accounts.views import EMAIL_CONFIRM_KEY
 from inclusion_connect.keycloak_compat.models import JWTHashSecret
 from inclusion_connect.keycloak_compat.utils import realm_from_request
-from inclusion_connect.oidc_overrides.views import OIDCSessionMixin
 from inclusion_connect.users.models import EmailAddress
+from inclusion_connect.utils.oidc import get_next_url
 
 
-class ActionToken(OIDCSessionMixin, View):
+class ActionToken(View):
     def get(self, request):
         try:
             request_jwt = request.GET["key"]
@@ -53,5 +53,5 @@ class ActionToken(OIDCSessionMixin, View):
                 return HttpResponseRedirect(url)
             email_address.verify()
             login(request, email_address.user)
-            return HttpResponseRedirect(self.get_success_url())
+            return HttpResponseRedirect(get_next_url(request))
         raise Http404

--- a/inclusion_connect/oidc_overrides/views.py
+++ b/inclusion_connect/oidc_overrides/views.py
@@ -17,6 +17,7 @@ from inclusion_connect.oidc_overrides.models import Application
 from inclusion_connect.oidc_overrides.validators import CustomOAuth2Validator
 from inclusion_connect.users.models import User, UserApplicationLink
 from inclusion_connect.utils.oidc import OIDC_SESSION_KEY, get_next_url, initial_from_login_hint
+from inclusion_connect.utils.urls import is_inclusion_connect_url
 
 
 class OIDCSessionMixin:
@@ -34,7 +35,7 @@ class OIDCSessionMixin:
 
     def setup(self, request, *args, **kwargs):
         next_url = request.GET.get("next")
-        if next_url:
+        if next_url and is_inclusion_connect_url(request, next_url):
             request.session["next_url"] = next_url
         return super().setup(request, *args, **kwargs)
 

--- a/inclusion_connect/oidc_overrides/views.py
+++ b/inclusion_connect/oidc_overrides/views.py
@@ -3,7 +3,7 @@ import json
 from django.contrib.auth import logout
 from django.contrib.sessions.models import Session
 from django.http import HttpResponseRedirect
-from django.urls import reverse, reverse_lazy
+from django.urls import reverse_lazy
 from django.utils import timezone
 from django.views.generic import View
 from jwcrypto import jwt
@@ -13,11 +13,10 @@ from oauth2_provider.http import OAuth2ResponseRedirect
 from oauth2_provider.models import get_access_token_model, get_id_token_model, get_refresh_token_model
 from oauth2_provider.settings import oauth2_settings
 
-from inclusion_connect.accounts.middleware import required_action_url
 from inclusion_connect.oidc_overrides.models import Application
 from inclusion_connect.oidc_overrides.validators import CustomOAuth2Validator
 from inclusion_connect.users.models import User, UserApplicationLink
-from inclusion_connect.utils.oidc import OIDC_SESSION_KEY, initial_from_login_hint
+from inclusion_connect.utils.oidc import OIDC_SESSION_KEY, get_next_url, initial_from_login_hint
 
 
 class OIDCSessionMixin:
@@ -30,14 +29,8 @@ class OIDCSessionMixin:
         initial.update(initial_from_login_hint(self.request))
         return initial
 
-    def get_next_url(self):
-        # We probably should add a message in this case to tell the user
-        # that something is fishy
-        return self.request.session.get("next_url") or reverse("accounts:edit_user_info")
-
     def get_success_url(self):
-        user = getattr(self, "object", self.request.user)  # in CreateView, user is stored in self.object
-        return required_action_url(user) or self.get_next_url()
+        return get_next_url(self.request)
 
     def setup(self, request, *args, **kwargs):
         next_url = request.GET.get("next")

--- a/inclusion_connect/utils/oidc.py
+++ b/inclusion_connect/utils/oidc.py
@@ -1,3 +1,8 @@
+from django.urls import reverse
+
+from inclusion_connect.accounts.middleware import required_action_url
+
+
 OIDC_SESSION_KEY = "oidc_params"
 
 
@@ -10,3 +15,13 @@ def initial_from_login_hint(request):
         return {"email": oidc_params(request)["login_hint"]}
     except KeyError:
         return {}
+
+
+def get_next_url(request):
+    next_url = required_action_url(request.user)
+    if not next_url:
+        try:
+            return request.session["next_url"]
+        except KeyError:
+            return reverse("accounts:edit_user_info")
+    return next_url

--- a/inclusion_connect/utils/oidc.py
+++ b/inclusion_connect/utils/oidc.py
@@ -19,9 +19,6 @@ def initial_from_login_hint(request):
 
 def get_next_url(request):
     next_url = required_action_url(request.user)
-    if not next_url:
-        try:
-            return request.session["next_url"]
-        except KeyError:
-            return reverse("accounts:edit_user_info")
-    return next_url
+    if next_url:
+        return next_url
+    return request.session.pop("next_url", reverse("accounts:edit_user_info"))

--- a/inclusion_connect/utils/urls.py
+++ b/inclusion_connect/utils/urls.py
@@ -1,6 +1,6 @@
 from urllib.parse import parse_qsl, urlparse
 
-from django.utils.http import urlencode
+from django.utils.http import url_has_allowed_host_and_scheme, urlencode
 
 
 def add_url_params(url: str, params: dict[str, str]) -> str:
@@ -29,3 +29,7 @@ def add_url_params(url: str, params: dict[str, str]) -> str:
 
 def get_url_params(url: str) -> dict[str, str]:
     return dict(parse_qsl(urlparse(url).query))
+
+
+def is_inclusion_connect_url(request, url):
+    return url_has_allowed_host_and_scheme(url, request.get_host(), require_https=request.is_secure())

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -69,6 +69,7 @@ def oidc_complete_flow(client, user):
     auth_url = reverse("oidc_overrides:authorize")
     auth_complete_url = add_url_params(auth_url, OIDC_PARAMS)
     response = client.get(auth_complete_url)
+    assert client.session["next_url"] == auth_complete_url
     response = client.post(
         response.url,
         data={
@@ -76,6 +77,8 @@ def oidc_complete_flow(client, user):
             "password": DEFAULT_PASSWORD,
         },
     )
+    # The redirect cleans `next_url` from the session.
+    assert "next_url" not in client.session
     response = client.get(response.url)
     auth_response_params = get_url_params(response.url)
     return oidc_flow_followup(client, auth_response_params, user)

--- a/tests/keycloak_compat/tests.py
+++ b/tests/keycloak_compat/tests.py
@@ -236,6 +236,8 @@ def test_user_account(client, realm):
     assert get_user(client).is_authenticated is True
     assertRedirects(response, account_url)
     assertContains(response, "Retour")
+    # The redirect cleans `next_url` from the session.
+    assert "next_url" not in client.session
 
 
 class TestActionToken:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -314,6 +314,8 @@ def test_edit_user_info_and_password(client, mailoutbox):
     response = client.post(response.url, data={"email": user.email, "password": DEFAULT_PASSWORD}, follow=True)
     assertRedirects(response, edit_user_info_url)
     assertContains(response, "<h1>\n                Informations générales\n            </h1>")
+    # The redirect cleans `next_url` from the session.
+    assert "next_url" not in client.session
 
     # Page contains return to referrer link
     assertContains(response, "Retour")
@@ -340,7 +342,7 @@ def test_edit_user_info_and_password(client, mailoutbox):
     assert verification_email.subject == "Vérification de l’adresse e-mail"
     verification_url = get_verification_link(verification_email.body)
     response = client.get(verification_url)
-    assertRedirects(response, edit_user_info_url)
+    assertRedirects(response, reverse("accounts:edit_user_info"))
 
     # Go change password
     response = client.get(change_password_url)

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import pytest
+from django.urls import reverse
+
+from inclusion_connect.utils.oidc import OIDC_SESSION_KEY
+from tests.users.factories import UserFactory
+
+
+@dataclass
+class OIDCSessionMixinTestInput:
+    requires_login: bool
+    viewname: str
+    oidc_data: Optional[Dict[str, str]]
+
+
+# All OIDCSessionMixin subclasses in the accounts app.
+OIDCSessionMixin_accounts: List[OIDCSessionMixinTestInput] = [
+    OIDCSessionMixinTestInput(False, "accounts:login", None),
+    OIDCSessionMixinTestInput(False, "accounts:register", None),
+    OIDCSessionMixinTestInput(
+        False,
+        "accounts:activate",
+        {"firstname": "Mercedes", "lastname": "Colomar", "login_hint": "m.c@mailinator.com"},
+    ),
+]
+
+
+@dataclass
+class NextUrlExpected:
+    next_url: str
+    expected: bool
+
+
+@pytest.mark.parametrize(
+    "testinput",
+    [
+        NextUrlExpected("https://evil.com", False),
+        NextUrlExpected("http://evil.com", False),
+        NextUrlExpected("/foobar", True),
+        NextUrlExpected("http://testserver/foobar", True),
+    ],
+)
+class TestOpenRedirectWithNextParameter:
+    @pytest.mark.parametrize("view", OIDCSessionMixin_accounts)
+    def test_accounts(self, client, testinput, view):
+        if view.requires_login:
+            client.force_login(UserFactory())
+        if view.oidc_data:
+            client_session = client.session
+            client_session[OIDC_SESSION_KEY] = view.oidc_data
+            client_session.save()
+        response = client.get(f"{reverse(view.viewname)}?next={testinput.next_url}")
+        assert response.status_code in [200, 302]
+        if testinput.expected:
+            assert client.session["next_url"] == testinput.next_url
+        else:
+            assert "next_url" not in client.session


### PR DESCRIPTION
Avoids subclassing `OIDCSessionMixin` in views that only need to know
the next URL. That avoids inheriting from unwanted behavior.