### PR TITLE
Add tests.helpers to pytest assert rewrite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from django.test.client import Client
 
 
-pytest.register_assert_rewrite("tests.asserts")
+pytest.register_assert_rewrite("tests.asserts", "tests.helpers")
 
 
 @pytest.hookimpl(tryfirst=True)


### PR DESCRIPTION
Assertions are made in the helpers module. Without it, a test failure
only shows `AssertionError` instead of the usual rewritten assert
showing operands and detailing the reason for failure.