### PR TITLE
Fix verified email inline admin

### DIFF
--- a/inclusion_connect/users/migrations/0004_emailaddress_verification.py
+++ b/inclusion_connect/users/migrations/0004_emailaddress_verification.py
@@ -17,9 +17,18 @@ class Migration(migrations.Migration):
             name="EmailAddress",
             fields=[
                 (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
                     "email",
                     django.contrib.postgres.fields.citext.CIEmailField(
-                        max_length=254, primary_key=True, serialize=False, verbose_name="adresse e-mail"
+                        db_index=True, max_length=254, verbose_name="adresse e-mail"
                     ),
                 ),
                 (

--- a/inclusion_connect/users/models.py
+++ b/inclusion_connect/users/models.py
@@ -65,7 +65,7 @@ class EmailAddress(models.Model):
     When the new email is verified, the old email address is deleted, user.email == new_email
     """
 
-    email = CIEmailField("adresse e-mail", primary_key=True)
+    email = CIEmailField("adresse e-mail", db_index=True)
     user = models.ForeignKey(User, on_delete=models.CASCADE, related_name="email_addresses")
     created_at = models.DateTimeField(editable=False, default=timezone.now, verbose_name="date de création")
     verified_at = models.DateTimeField(null=True, blank=True, verbose_name="date de vérification")
@@ -102,7 +102,7 @@ class EmailAddress(models.Model):
         # Free unused email addresses for other users.
         type(self).objects.filter(user_id=self.user_id).exclude(pk=self.pk).delete()
         self.verified_at = verified_at or timezone.now()
-        self.save(update_fields=["verified_at"])
+        self.save()
 
 
 class UserApplicationLink(models.Model):


### PR DESCRIPTION
Since the introduction of constraints (only one verified and unverified
email per user), the admin saving of email addresses breaks constraints
before to call `verify`, which would bring the situation back to a
normal state.

The main issue is using the `email` field as the PK of `EmailAddress`
prevents django from following that the instance did not change. When
foo@bar.com is changed to baz@bar.com, django cannot tell if baz@bar.com
is an existing instance being updated, or a new instance (with the old
one being delete). To help django keep track of EmailAddress instances,
introduce an `id` for EmailAddress.

Since the service is not live, rewrite the migration history instead of
crafting a real migration of the primary key, which is cumbersome.