### PR TITLE
Ajout d'une variante HTML à l'email de réinitialisation de mot de passe

### DIFF
--- a/inclusion_connect/accounts/forms.py
+++ b/inclusion_connect/accounts/forms.py
@@ -150,9 +150,6 @@ class ActivateAccountForm(RegisterForm):
 
 
 class PasswordResetForm(auth_forms.PasswordResetForm):
-    # email subject in templates/registration/password_reset_subject.txt
-    # email body in templates/registration/password_reset_email.html
-
     def __init__(self, *args, initial, **kwargs):
         super().__init__(*args, initial=initial, **kwargs)
         email_field = self.fields["email"]
@@ -162,9 +159,6 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
 
 
 class SetPasswordForm(auth_forms.SetPasswordForm):
-    # email subject in templates/registration/password_reset_subject.txt
-    # email body in templates/registration/password_reset_email.html
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         for key in ["new_password1", "new_password2"]:

--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -92,6 +92,9 @@ class ActivateAccountView(BaseUserCreationView):
 
 class PasswordResetView(auth_views.PasswordResetView):
     template_name = "password_reset.html"
+    subject_template_name = "registration/password_reset_subject.txt"
+    email_template_name = "registration/password_reset_email.txt"
+    html_email_template_name = "registration/password_reset_email.html"
     form_class = forms.PasswordResetForm
 
     def get_initial(self):

--- a/inclusion_connect/templates/registration/email_verification_body.txt
+++ b/inclusion_connect/templates/registration/email_verification_body.txt
@@ -8,5 +8,5 @@ afin de vérifier votre adresse e-mail :
 
 Ce lien expire dans 1 jour.
 
-Sinon, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.
+Si vous n’êtes pas à l’origine de cette demande, veuillez ignorer ce message.
 {% endblock body %}

--- a/inclusion_connect/templates/registration/password_reset_email.html
+++ b/inclusion_connect/templates/registration/password_reset_email.html
@@ -1,10 +1,17 @@
 {% extends "layout/base_email_body.html" %}
 {% block body %}
-    Une demande de réinitialisation de mot de passe a été effectuée pour votre compte. Si vous êtes à l’origine de cette requête, veuillez cliquer sur le lien ci-dessous pour le mettre à jour.
+    <p>
+        Une demande de réinitialisation de mot de passe a été effectuée pour
+        votre compte. Si vous êtes à l’origine de cette requête&nbsp;:
+        <br>
+    </p>
+    <p>
+        <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">Réinitialiser votre mot de passe</a>.
+    </p>
 
-    {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+    <p>Ce lien expire dans 1 jour.</p>
 
-    Ce lien expire dans 1 jour.
-
-    Sinon, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.
+    <p>
+        <i>Si vous n’êtes pas à l’origine de cette demande, veuillez ignorer ce message.</i>
+    </p>
 {% endblock body %}

--- a/inclusion_connect/templates/registration/password_reset_email.txt
+++ b/inclusion_connect/templates/registration/password_reset_email.txt
@@ -1,0 +1,10 @@
+{% extends "layout/base_email_body.html" %}
+{% block body %}
+Une demande de réinitialisation de mot de passe a été effectuée pour votre compte. Si vous êtes à l’origine de cette requête, veuillez cliquer sur le lien ci-dessous pour le mettre à jour.
+
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+
+Ce lien expire dans 1 jour.
+
+Si vous n’êtes pas à l’origine de cette demande, veuillez ignorer ce message.
+{% endblock body %}

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -188,7 +188,7 @@ class TestRegisterView:
             "afin de vérifier votre adresse e-mail :\n\n"
             f"{verify_link}\n\n"
             "Ce lien expire dans 1 jour.\n\n"
-            "Sinon, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.\n\n"
+            "Si vous n’êtes pas à l’origine de cette demande, veuillez ignorer ce message.\n\n"
             "---\n"
             "L’équipe d’inclusion connect\n"
         )
@@ -358,7 +358,7 @@ class TestRegisterView:
             "afin de vérifier votre adresse e-mail :\n\n"
             f"{verify_link}\n\n"
             "Ce lien expire dans 1 jour.\n\n"
-            "Sinon, veuillez ignorer ce message ; aucun changement ne sera effectué sur votre compte.\n\n"
+            "Si vous n’êtes pas à l’origine de cette demande, veuillez ignorer ce message.\n\n"
             "---\n"
             "L’équipe d’inclusion connect\n"
         )


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Refonte-mail-de-r-initialisation-de-mot-de-passe-ajouter-une-variante-HTML-d40b482a34d54955a24d60d2f89a769e?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Pour que ce soir plus joli
