### PR TITLE
Remove permissions fieldset from staff user admin

### DIFF
--- a/inclusion_connect/users/apps.py
+++ b/inclusion_connect/users/apps.py
@@ -1,6 +1,31 @@
 from django.apps import AppConfig
+from django.db import models
 
 
 class AnalyticsConfig(AppConfig):
     name = "inclusion_connect.users"
     verbose_name = "Utilisateurs"
+
+    def ready(self):
+        super().ready()
+        models.signals.post_migrate.connect(ensure_support_group, sender=self)
+
+
+def ensure_support_group(*args, **kwargs):
+    from django.contrib.auth.models import Group, Permission
+
+    group, _created = Group.objects.get_or_create(name="support")
+    group.permissions.set(
+        Permission.objects.filter(
+            codename__in=[
+                "add_user",
+                "change_user",
+                "view_user",
+                "add_emailaddress",
+                "change_emailaddress",
+                "delete_emailaddress",
+                "view_emailaddress",
+                "view_userapplicationlink",
+            ]
+        )
+    )

--- a/inclusion_connect/users/migrations/0001_initial.py
+++ b/inclusion_connect/users/migrations/0001_initial.py
@@ -103,8 +103,7 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
-                "verbose_name": "user",
-                "verbose_name_plural": "users",
+                "verbose_name": "utilisateur",
                 "abstract": False,
             },
             managers=[

--- a/inclusion_connect/users/migrations/0004_emailaddress_verification.py
+++ b/inclusion_connect/users/migrations/0004_emailaddress_verification.py
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterModelOptions(
             name="user",
-            options={},
+            options={"verbose_name": "utilisateur"},
         ),
         migrations.AlterField(
             model_name="user",

--- a/inclusion_connect/users/models.py
+++ b/inclusion_connect/users/models.py
@@ -27,6 +27,7 @@ class User(AbstractUser):
     terms_accepted_at = models.DateTimeField("date de validation des CGUs", blank=True, null=True)
 
     class Meta:
+        verbose_name = "utilisateur"
         constraints = [
             models.UniqueConstraint(
                 "email",


### PR DESCRIPTION
Make the permission fields readonly, to prevent a staff admin from
updating a user permissions.

Refs https://code.djangoproject.com/ticket/23559