### PR TITLE
Charger une clé RSA sur une ligne 

### DIFF
--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -298,9 +298,22 @@ EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
 # Django-oauth-toolkit
 # --------------------
 
+one_lined_rsa_private_key = os.environ.get("OIDC_RSA_PRIVATE_KEY")
+OIDC_RSA_PRIVATE_KEY = f"""{one_lined_rsa_private_key[:27]}
+{one_lined_rsa_private_key[27:-25]}
+{one_lined_rsa_private_key[-25:]}"""
+
+assert (
+    OIDC_RSA_PRIVATE_KEY.splitlines()[0] == "-----BEGIN PRIVATE KEY-----"
+), "Bad rsa key format, we expect a one-lined PEM key starting with '-----BEGIN PRIVATE KEY----'"
+assert (
+    OIDC_RSA_PRIVATE_KEY.splitlines()[2] == "-----END PRIVATE KEY-----"
+), "Bad rsa key format, we expect a one-lined PEM key ending with '-----END PRIVATE KEY----'"
+
+
 OAUTH2_PROVIDER = {
     "OIDC_ENABLED": True,
-    "OIDC_RSA_PRIVATE_KEY": os.environ.get("OIDC_RSA_PRIVATE_KEY"),
+    "OIDC_RSA_PRIVATE_KEY": OIDC_RSA_PRIVATE_KEY,
     "SCOPES": {
         "openid": "OpenID Connect scope",
         "profile": "Profil utilisateur",


### PR DESCRIPTION
**Carte Notion : **

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

les clé RSA au format PEM sont sur plusieurs lignes, ce qui ne plait pas à sops.
Plutot que de se compliquer la vie à changer de format ou à utiliser un fichier séparé pour la clé, on va juste la passer sur une seule ligne dans la config

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

