### PR TITLE
Add space before “12 chars minimum” criterion on pw input

### DIFF
--- a/inclusion_connect/templates/includes/new_password.html
+++ b/inclusion_connect/templates/includes/new_password.html
@@ -4,7 +4,7 @@
 <small class="form-text text-muted">
     <ul class="list-unstyled">
         <li>
-            <i id="pw-length" class="ri-close-circle-line text-warning"></i>12 caractères minimum
+            <i id="pw-length" class="ri-close-circle-line text-warning"></i> 12 caractères minimum
         </li>
         <li>
             <i id="pw-digit" class="ri-close-circle-line text-warning"></i> 1 chiffre


### PR DESCRIPTION
Probably removed during a reformatting.

### Avant

![image](https://github.com/gip-inclusion/inclusion-connect/assets/2758243/bc27fad6-5ed5-4f95-a48c-f97815da6259)

### Après

![image](https://github.com/gip-inclusion/inclusion-connect/assets/2758243/5d5472ec-5d26-4099-b52c-0432bb935900)
