### PR TITLE
Hide password validators help text from password field

### DIFF
--- a/inclusion_connect/utils/templatetags/inclusionconnect_fields.py
+++ b/inclusion_connect/utils/templatetags/inclusionconnect_fields.py
@@ -16,6 +16,9 @@ def make_password_field(form_field, field_class=None):
         """,
         addon_after_class=None,
         field_class=field_class,
+        # Otherwise, password validators rules are displayed in a <ul>,
+        # which duplicated the indicators from new_password.html.
+        show_help=False,
     )
 
 

--- a/tests/__snapshots__/test_template_tags.ambr
+++ b/tests/__snapshots__/test_template_tags.ambr
@@ -1,0 +1,11 @@
+# serializer version: 1
+# name: test_new_password_display[new password has instructions]
+  '''
+  <div class="form-group form-group-required"><label for="id_password1">Mot de passe</label><div class="password-with-instructions"><div class="input-group"><input autocomplete="new-password" class="form-control" id="id_password1" name="password1" placeholder="**********" required="" title="" type="password"/><div class="input-group-append">
+          <button class="btn btn-sm btn-link btn-ico" data-password="toggle" type="button">
+              <i class="ri-eye-line"></i>
+              <span>Afficher</span>
+          </button>
+          </div></div></div></div>
+  '''
+# ---

--- a/tests/test_template_tags.py
+++ b/tests/test_template_tags.py
@@ -1,0 +1,9 @@
+from bs4 import BeautifulSoup
+from django.urls import reverse
+
+
+def test_new_password_display(client, snapshot):
+    response = client.get(reverse("accounts:register"))
+    soup = BeautifulSoup(response.content, "html5lib", from_encoding=response.charset)
+    form_group = soup.find("label", attrs={"for": "id_password1"}).parent
+    assert str(form_group) == snapshot(name="new password has instructions")


### PR DESCRIPTION
**Carte Notion : **
https://www.notion.so/plateforme-inclusion/Affichage-des-crit-res-ad8938f3822247318124d861aff78df4


### Pourquoi ?

Each registered password validator can provide a help text. They are pretty
verbose and conflict with dynamic password indicators.