### PR TITLE
Correction du formulaire de demande de réinitialisation de mot de passe 

### DIFF
--- a/inclusion_connect/accounts/forms.py
+++ b/inclusion_connect/accounts/forms.py
@@ -161,8 +161,10 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
         super().save(*args, request=request, **kwargs)
         email = self.cleaned_data["email"]
         if next_url := request.session.get("next_url"):
-            [user] = self.get_users(email)
-            user.save_next_redirect_uri(next_url)
+            users = list(self.get_users(email))
+            if users:
+                [user] = users
+                user.save_next_redirect_uri(next_url)
 
 
 class SetPasswordForm(auth_forms.SetPasswordForm):


### PR DESCRIPTION
Quand l'email n'existe pas, le formulaire plante (erreur 500)