### PR TITLE
Redirect to edit_user_info when CSRF failed

### DIFF
--- a/inclusion_connect/templates/403_csrf.html
+++ b/inclusion_connect/templates/403_csrf.html
@@ -6,7 +6,8 @@
             Peut-être vous êtes-vous connecté depuis un autre onglet ?
         </p>
         <p class="mb-0">
-            Veuillez <a href="">recharger la page</a>.
+            Pour continuer à utiliser Inclusion Connect,
+            <a href="{% url "accounts:edit_user_info" %}">retournez sur la page de gestion de votre compte</a>.
         </p>
     </div>
 {% endblock %}

--- a/tests/__snapshots__/test_builtin_views.ambr
+++ b/tests/__snapshots__/test_builtin_views.ambr
@@ -60,7 +60,8 @@
               Peut-être vous êtes-vous connecté depuis un autre onglet ?
           </p>
           <p class="mb-0">
-              Veuillez <a href="">recharger la page</a>.
+              Pour continuer à utiliser Inclusion Connect,
+              <a href="/accounts/my-account/">retournez sur la page de gestion de votre compte</a>.
           </p>
       </div>
   


### PR DESCRIPTION
**Carte Notion: https://www.notion.so/plateforme-inclusion/Je-demande-le-renvoi-d-un-email-alors-qu-email-valid-cran-bug-ad1ccf61d94745e49a23ac34e3591ce4?d=a6e16f719ae94a1f8a8779daa40e7ee0**

Reloading the page leads to a 404, when the user is on email confirm
view and has consumed the email session key in another tab/browser.
Instead of trying to be smart, juste direct users back to a valid page
in the application. If we had a landing page, that would be the ideal
target.