### PR TITLE
Fix typo in TestUserAdmin::test_add_verified_email

### DIFF
--- a/tests/users/test_admin.py
+++ b/tests/users/test_admin.py
@@ -197,7 +197,7 @@ class TestUserAdmin:
                 # Specifying the old email address
                 "email_addresses-0-id": email_address.pk,
                 "email_addresses-0-user": user.pk,
-                "email_addresses-0-email": "me@mailinator.com",
+                "email_addresses-0-email": "other@mailinator.com",
                 "email_addresses-0-verified_at_0": "",
                 "email_addresses-0-verified_at_1": "",
                 "email_addresses-0-DELETE": "on",


### PR DESCRIPTION
It’s a bit silly to add another entry instead of verifying the existing
one. Clarify between the other (unverified) email and the new email
being added through the admin.