### PR TITLE
Prefer localhost over 127.0.0.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,14 +15,14 @@ services:
       - postgres_data:/var/lib/postgresql/data
     restart: always
     ports:
-      - "127.0.0.1:${POSTGRES_PORT_ON_DOCKER_HOST:-5433}:5432"
+      - "localhost:${POSTGRES_PORT_ON_DOCKER_HOST:-5433}:5432"
 
   smtp:
     container_name: inclusion_connect_smtp
     image: mailhog/mailhog
     ports:
-      - 127.0.0.1:1025:1025
-      - 127.0.0.1:8025:8025
+      - localhost:1025:1025
+      - localhost:8025:8025
 
 volumes:
   postgres_data:

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,7 +26,7 @@ NB: le port exposé est le `5433` car si vous travaillez déjà avec un PSQL, il
 
 Afin d'avoir accès aux mails envoyés par Inclusion Connect en local, notre `docker-compose.yml` lance une image docker de [MailHog](https://github.com/mailhog/MailHog).
 
-MailHog donne accès à un faux webmail à l'addresse http://127.0.0.1:8025 qui permet d'afficher tous les emails qui sont envoyés.
+MailHog donne accès à un faux webmail à l'addresse http://localhost:8025 qui permet d'afficher tous les emails qui sont envoyés.
 Cela permet de ne pas avoir besoin d'un vrai serveur SMTP et d'une vraie adresse email.
 
 ## Générer une clé RSA
@@ -74,7 +74,7 @@ Pour utiliser le service il faut les identifiantes suivants :
 
 ## Normalement tout est bon !
 
-Si tout va bien (croisons les doigts) vous aurez accès à l'admin : `http://127.0.0.1:8080/admin`
+Si tout va bien (croisons les doigts) vous aurez accès à l'admin : `http://localhost:8080/admin`
 et aux autres urls.
 
 Il faudra utiliser le couple `local_inclusion_connect`/`password` comme indiqué précédement pour se connecter avec un client OpenID Connect

--- a/docs/user_journey.md
+++ b/docs/user_journey.md
@@ -16,7 +16,7 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/authorize?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2F127.0.0.1%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
+    http://0.0.0.0:8080/auth/authorize?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
 
     L’url est celle de l’endpoint Authorization: `https://{hostname}/auth/authorize`
 
@@ -41,7 +41,7 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/register?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2F127.0.0.1%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W&from=emplois
+    http://0.0.0.0:8080/auth/register?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W&from=emplois
 
     L’url est celle de l’endpoint Registration: `https://{hostname}/auth/register`
 
@@ -86,7 +86,7 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/authorize?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2F127.0.0.1%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
+    http://0.0.0.0:8080/auth/authorize?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
 
     L’url est celle de l’endpoint Authorization: `https://{hostname}/auth/authorize`
 
@@ -117,7 +117,7 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/authorize?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2F127.0.0.1%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
+    http://0.0.0.0:8080/auth/authorize?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
 
     L’url est celle de l’endpoint Authorization: `https://{hostname}/auth/authorize`
 
@@ -174,7 +174,7 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/activate?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2F127.0.0.1%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=mJGvp3qwBMkD%3AYedrAibh8pHw0yx3mY8-L2Zp-vhLe8D-rL2aClHm9zQ&nonce=CbBAoMxEUIJR&login_hint=mon%40email.com&lastname=Nom&firstname=Pr%C3%A9nom
+    http://0.0.0.0:8080/auth/activate?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=mJGvp3qwBMkD%3AYedrAibh8pHw0yx3mY8-L2Zp-vhLe8D-rL2aClHm9zQ&nonce=CbBAoMxEUIJR&login_hint=mon%40email.com&lastname=Nom&firstname=Pr%C3%A9nom
 
     L’url est celle de l’endpoint Registration: `https://{hostname}/auth/activate`
 
@@ -229,7 +229,7 @@ La déconnexion peut être faite de deux manières:
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/realms/local/protocol/openid-connect/logout?client_id=local_inclusion_connect&post_logout_redirect_uri=http%3A%2F%2F127.0.0.1%3A8000
+    http://0.0.0.0:8080/realms/local/protocol/openid-connect/logout?client_id=local_inclusion_connect&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8000
 
     L’url est celle de l’endpoint Logout: `https://{hostname}/realms/{realm-name}/protocol/openid-connect/logout`
 
@@ -257,7 +257,7 @@ Pour se faire, il faut passer les paramètres (`referrer` et `referrer_uri`, voi
 - <details>
   <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-  http://0.0.0.0:8080/accounts/my-account?referrer=local_inclusion_connect&referrer_uri=http%3A%2F%2F127.0.0.1%3A8000%2Finclusion_connect%2Fauthorize%3Fnext_url%3Dhttp%253A%252F%252F127.0.0.1%253A8000%252Fdashboard%252Fedit_user_info%26user_kind%3Dprescriber
+  http://0.0.0.0:8080/accounts/my-account?referrer=local_inclusion_connect&referrer_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fauthorize%3Fnext_url%3Dhttp%253A%252F%252Flocalhost%253A8000%252Fdashboard%252Fedit_user_info%26user_kind%3Dprescriber
 
   L’url est : `https://{hostname}/accounts/my-account`
 

--- a/inclusion_connect/utils/urls.py
+++ b/inclusion_connect/utils/urls.py
@@ -10,10 +10,10 @@ def add_url_params(url: str, params: dict[str, str]) -> str:
     :param params: dict containing requested params to be added
     :return: string with updated URL
 
-    >> url = 'http://127.0.0.1:8000/login/activate_siae_staff_account?next_url=%2Finvitations
+    >> url = 'http://localhost:8000/login/activate_siae_staff_account?next_url=%2Finvitations
     >> new_params = {'test': 'value' }
     >> add_url_params(url, new_params)
-    'http://127.0.0.1:8000/login/activate_siae_staff_account?next_url=%2Finvitations&test=value
+    'http://localhost:8000/login/activate_siae_staff_account?next_url=%2Finvitations&test=value
     """
 
     # Remove params with None values


### PR DESCRIPTION
### Pourquoi ?

127.0.0.1 is so IPv4…

Unifying on localhost helps with various allowlists (ALLOWED_HOSTS,
redirect_uris, post_logout_redirect_uris).