### PR TITLE
Tailor application fixtures for “Les emplois de l’inclusion”

### DIFF
--- a/inclusion_connect/fixtures/django/02_oauth_overrides_application.json
+++ b/inclusion_connect/fixtures/django/02_oauth_overrides_application.json
@@ -4,8 +4,8 @@
     "pk": 1,
     "fields": {
       "client_id": "local_inclusion_connect",
-      "redirect_uris": "http://localhost/*",
-      "post_logout_redirect_uris": "http://callback/*",
+      "redirect_uris": "http://localhost:8000/*",
+      "post_logout_redirect_uris": "http://locahost:8000/*",
       "client_type": "confidential",
       "authorization_grant_type": "authorization-code",
       "client_secret": "pbkdf2_sha256$390000$gFdrmQbzl6Z4prHIHo9ryp$IV2jnKuEqT5Y+iZPnaXprkSJCV3Gnu28h0dchm08+lo=",


### PR DESCRIPTION
### Pourquoi ?

The port is part of the netloc verified by `redirect_uris`. Configure
the fixture so that it works with “Les emplois de l’inclusion” by
default.