### PR TITLE
Add logging to Inclusion Connect

### DIFF
--- a/inclusion_connect/logging.py
+++ b/inclusion_connect/logging.py
@@ -1,0 +1,24 @@
+from pythonjsonlogger import jsonlogger
+
+from inclusion_connect.utils.oidc import oidc_params
+
+
+def log_data(request):
+    log_data = {"ip_address": request.META["REMOTE_ADDR"]}
+    params = oidc_params(request)
+    try:
+        log_data["application"] = params["client_id"]
+    except KeyError:
+        pass
+    return log_data
+
+
+class JsonFormatter(jsonlogger.JsonFormatter):
+    def parse(self):
+        # Remove the empty key "message".
+        return []
+
+    def add_fields(self, log_record, record, message_dict):
+        super().add_fields(log_record, record, message_dict)
+        for record_attr in ["name", "levelname"]:
+            log_record[record_attr] = getattr(record, record_attr)

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -15,6 +15,7 @@ import os
 from pathlib import Path
 
 import dj_database_url
+from django.core.serializers.json import DjangoJSONEncoder
 from dotenv import load_dotenv
 
 
@@ -202,16 +203,17 @@ LOGGING = {
     "handlers": {
         "console": {"class": "logging.StreamHandler"},
         "null": {"class": "logging.NullHandler"},
-        "api_console": {
+        "json_handler": {
             "class": "logging.StreamHandler",
-            "formatter": "api_simple",
+            "formatter": "json_formatter",
         },
     },
     "formatters": {
-        "api_simple": {
-            "format": "{levelname} {asctime} {pathname} : {message}",
-            "style": "{",
-        },
+        "json_formatter": {
+            "()": "inclusion_connect.logging.JsonFormatter",
+            "json_encoder": DjangoJSONEncoder,
+            "timestamp": True,
+        }
     },
     "loggers": {
         "django": {
@@ -226,7 +228,7 @@ LOGGING = {
             "propagate": False,
         },
         "inclusion_connect": {
-            "handlers": ["console"],
+            "handlers": ["json_handler"],
             "level": os.getenv("IC_LOG_LEVEL", "INFO"),
         },
     },

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -229,17 +229,6 @@ LOGGING = {
             "handlers": ["console"],
             "level": os.getenv("IC_LOG_LEVEL", "INFO"),
         },
-        # Logger for DRF API application
-        # Will be "log-drained": may need to adjust format
-        "api_drf": {
-            "handlers": ["api_console"],
-            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
-        },
-        # Huey; async tasks
-        "huey": {
-            "handlers": ["console"],
-            "level": os.getenv("HUEY_LOG_LEVEL", "WARNING"),
-        },
     },
 }
 

--- a/inclusion_connect/users/admin.py
+++ b/inclusion_connect/users/admin.py
@@ -1,14 +1,22 @@
 import copy
+import logging
+from functools import partial
 
 from django import forms
 from django.contrib import admin
 from django.contrib.auth import admin as auth_admin, forms as auth_forms, password_validation
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.db.models import F, Prefetch
 from django.forms.formsets import DELETION_FIELD_NAME
 from django.utils.safestring import mark_safe
 
+from inclusion_connect.logging import log_data
+
 from .models import EmailAddress, User, UserApplicationLink
+
+
+logger = logging.getLogger("inclusion_connect.auth")
 
 
 def is_email_verified(form):
@@ -138,15 +146,49 @@ class UserChangeForm(auth_forms.UserChangeForm):
         ):
             raise ValidationError("Vous ne pouvez pas à la fois modifier l'email validé, et confirmer un email")
 
+    def confirmed_email(self):
+        return self.cleaned_data["confirm_email"]
+
+    def changed_verified_email(self):
+        return self.initial["email"] != self.cleaned_data["email"]
+
     def save(self, commit=True):
-        new_email = self.cleaned_data["email"]
-        if self.cleaned_data["confirm_email"]:
+        if self.confirmed_email():
             self.instance.email_to_validate[0].verify()
             self.instance.email = self.instance.email_to_validate[0].email
-        elif self.initial["email"] != new_email:
-            email_address = EmailAddress(user=self.instance, email=new_email)
+        elif self.changed_verified_email():
+            email_address = EmailAddress(user=self.instance, email=self.cleaned_data["email"])
             email_address.verify()
         return super().save(commit=commit)
+
+    def log_changes(self, request):
+        log = log_data(request)
+        log["event"] = "admin_change"
+        log["acting_user"] = request.user.pk
+        log["user"] = self.instance.pk
+        tracked_changed_fields = set(self.changed_data) & {"first_name", "last_name"}
+        for field in sorted(tracked_changed_fields):
+            log[f"old_{field}"] = self.initial[field]
+            log[f"new_{field}"] = self.cleaned_data[field]
+        if self.confirmed_email():
+            log["email_confirmed"] = self.instance.email_to_validate[0].email
+        elif self.changed_verified_email():
+            log["email_changed"] = self.cleaned_data["email"]
+        if "groups" in self.changed_data:
+            current_groups = set(self.initial["groups"])
+            new_groups = set(self.cleaned_data["groups"])
+            log["groups"] = {}
+            added_groups = new_groups - current_groups
+            if added_groups:
+                log["groups"]["added"] = {}
+                for group in added_groups:
+                    log["groups"]["added"][group.pk] = group.name
+            removed_groups = current_groups - added_groups
+            if removed_groups:
+                log["groups"]["removed"] = {}
+                for group in current_groups - new_groups:
+                    log["groups"]["removed"][group.pk] = group.name
+        transaction.on_commit(partial(logger.info, log))
 
 
 @admin.register(User)
@@ -174,6 +216,30 @@ class UserAdmin(auth_admin.UserAdmin):
             return email_to_validate[0].email
         else:
             return None
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if change:
+            form.log_changes(request)
+        else:
+            log = log_data(request)
+            log["event"] = "admin_add"
+            log["acting_user"] = request.user.pk
+            log["user"] = form.instance.pk
+            transaction.on_commit(partial(logger.info, log))
+
+    def construct_change_message(self, request, form, formsets, add=False):
+        """
+        Abusing the only method called with the request and user when a change_password succeeded.
+        """
+        change_message = super().construct_change_message(request, form, formsets, add=add)
+        if isinstance(form, self.change_password_form):
+            log = log_data(request)
+            log["event"] = "admin_change_password"
+            log["acting_user"] = request.user.pk
+            log["user"] = form.user.pk
+            transaction.on_commit(partial(logger.info, log))
+        return change_message
 
     def get_fieldsets(self, request, obj=None):
         fieldsets = super().get_fieldsets(request, obj)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -38,3 +38,4 @@ python-dotenv  # https://github.com/theskumar/python-dotenv
 # ------------------------------------------------------------------------------
 uwsgi==2.0.*  # https://github.com/unbit/uwsgi
 sentry-sdk  # https://github.com/getsentry/sentry-python
+python-json-logger  # https://github.com/madzak/python-json-logger

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -261,6 +261,10 @@ python-dotenv==1.0.0 \
     --hash=sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba \
     --hash=sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a
     # via -r requirements/base.in
+python-json-logger==2.0.7 \
+    --hash=sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c \
+    --hash=sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd
+    # via -r requirements/base.in
 requests==2.31.0 \
     --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
     --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -626,6 +626,10 @@ python-dotenv==1.0.0 \
     --hash=sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba \
     --hash=sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a
     # via -r requirements/base.txt
+python-json-logger==2.0.7 \
+    --hash=sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c \
+    --hash=sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd
+    # via -r requirements/base.txt
 pyyaml==6.0 \
     --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf \
     --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293 \

--- a/tests/__snapshots__/test_logging.ambr
+++ b/tests/__snapshots__/test_logging.ambr
@@ -1,0 +1,8 @@
+# serializer version: 1
+# name: test_log_formatting[log serialized as JSON with metadata]
+  '''
+  {"key": "value", "other_key": "value", "timestamp": "2023-05-05T11:11:11Z", "name": "inclusion_connect", "levelname": "INFO"}
+  INFO:inclusion_connect:{'key': 'value', 'other_key': 'value'}
+  
+  '''
+# ---

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -1610,7 +1610,7 @@ class TestChangeTemporaryPasswordView:
         assert user.must_reset_password is False
 
     def test_invalid_password(self, caplog, client):
-        user = UserFactory(must_reset_password=True)
+        user = UserFactory(must_reset_password=True, first_name="Manuel", last_name="Calavera")
         client.force_login(user)
         response = client.post(
             reverse("accounts:change_temporary_password"),

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,13 @@
+import logging
+
+from freezegun import freeze_time
+
+
+@freeze_time("2023-05-05 11:11:11")
+def test_log_formatting(snapshot):
+    logger = logging.getLogger("inclusion_connect")  # Root logger for IC.
+    [handler] = logger.handlers
+    logger.info({"key": "value", "other_key": "value"})
+    stream = handler.stream
+    stream.seek(0)
+    assert stream.read() == snapshot(name="log serialized as JSON with metadata")


### PR DESCRIPTION
**Carte Notion: https://www.notion.so/plateforme-inclusion/Refonte-Audits-logs-ed9a34eb17774b8e8ecbc3eac001220b**

With the goal of sending the logs to ElasticSearch, logs are structured
with the JSON format.

Loggers are nested under the `inclusion_connect` root:
- `inclusion_connect.auth` handles authentication
- `inclusion_connect.oidc` handles the OpenID Connect protocol

Users are represented by their PK (UUID). Applications are represented by
their `client_id`.

Logs are sent `on_commit`, in an attempt to only log actions that actually
happened.

All logs have an `action` key, identifying what was performed. When the
acting user is different from the user (i.e. Django admin), an
`acting_user` key is added to the event.

When the client session is lost (changed browser), the OIDC application is
lost until the client resumes OIDC. The 'application' key is missing from
the logs in that case. That’s considered a minor inconvenience, because:
- the application is logged when the user navigates on IC (until they
lose their session, which often happens when they open the link from
an email sent by IC)
- the user should immediately be redirected to their application when
proceeding with OIDC authorize. The redirect is logged and allows deducing
the relying party.

`caplog` was added to `oidc_flow_followup`, to ensure logging was
considered in all code paths.