### PR TITLE
Empêcher les administrateur d'utiliser les vues en dehors de l'admin

### DIFF
--- a/inclusion_connect/middleware.py
+++ b/inclusion_connect/middleware.py
@@ -1,4 +1,7 @@
+from django.core.exceptions import PermissionDenied
+from django.urls import reverse
 from django.utils.cache import add_never_cache_headers
+from django.utils.html import format_html
 
 
 def never_cache(get_response):
@@ -7,5 +10,22 @@ def never_cache(get_response):
         if request.user.is_authenticated:
             add_never_cache_headers(response)
         return response
+
+    return middleware
+
+
+def limit_staff_users_to_admin(get_response):
+    def middleware(request):
+        user = request.user
+
+        if user.is_staff and not request.path.startswith("/admin/"):
+            exception = format_html(
+                "Les comptes administrateurs n'ont pas accès à cette page.<br>"
+                '<a href="{}">Vous pouvez-vous déconnecter ici.</a>',
+                reverse("admin:logout"),
+            )
+            raise PermissionDenied(exception)
+
+        return get_response(request)
 
     return middleware

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -73,6 +73,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "inclusion_connect.middleware.never_cache",
+    "inclusion_connect.middleware.limit_staff_users_to_admin",
     "inclusion_connect.accounts.middleware.post_login_actions",
 ]
 

--- a/inclusion_connect/templates/403.html
+++ b/inclusion_connect/templates/403.html
@@ -1,0 +1,10 @@
+{% extends "layout/left_content.html" %}
+{% block content %}
+    {% if exception %}
+        <div class="alert alert-warning">
+            <p class="mb-0">{{ exception }}</p>
+        </div>
+    {% else %}
+        <h1 class="h2">Accès refusé</h1>
+    {% endif %}
+{% endblock %}

--- a/inclusion_connect/wsgi.py
+++ b/inclusion_connect/wsgi.py
@@ -12,6 +12,6 @@ import os
 from django.core.wsgi import get_wsgi_application
 
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.prod")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inclusion_connect.settings.base")
 
 application = get_wsgi_application()


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Refonte-s-paration-des-sessions-admin-applicatif-d759e5cf02e1473ab215c3d5285ec77f?pvs=4

### Pourquoi ?

Permet de ne pas utiliser l'utilisateur connecté sur l'admin pour les vues en dehors de l'admin
