### PR TITLE
Corriger les logouts multiples

### DIFF
--- a/tests/oidc_overrides/tests.py
+++ b/tests/oidc_overrides/tests.py
@@ -104,8 +104,8 @@ class TestLogoutView:
             assert has_ongoing_sessions(user) is False
             assert token_are_revoked(user) is True
 
-    def test_bad_login_hint(self, client):
-        """This test simulates a call on logout endpoint with bad login hint"""
+    def test_bad_id_token_hint_with_logged_in_user_fails(self, client):
+        """This test simulates a call on logout endpoint with an unknown id_token_hint"""
         user = UserFactory()
         oidc_complete_flow(client, user)
 
@@ -117,6 +117,16 @@ class TestLogoutView:
         assert token_are_revoked(user) is False
         assert get_user(client).is_authenticated is True
         assert has_ongoing_sessions(user) is True
+
+    def test_bad_id_token_hint_with_no_redirect_uri(self, client):
+        """This test simulates a call on logout endpoint with an unknown id_token_hint"""
+        response = call_logout(client, "get", {"id_token_hint": 111})
+        assertRedirects(response, "http://testserver/", fetch_redirect_response=False)
+
+    def test_bad_id_token_hint_with_unknown_redirect_uri_fails(self, client):
+        """This test simulates a call on logout endpoint with an unknown id_token_hint"""
+        response = call_logout(client, "get", {"id_token_hint": 111, "post_logout_redirect_uri": "http://callback/"})
+        assert response.status_code == 400
 
     def test_logout_clear_all_clients_sessions(self, client):
         user = UserFactory()


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Refonte-bug-de-logout-multiples-e5d309cd2296464c8bf0acb71610b072?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Comme la lib supprime les ID Tokens au logout, si on reçoit un logout pour un même utilisateur depuis un autre partenaire, le token n'existera plus, et le logout va planter.

Il faudrait conserver les tokens lorsqu'ils sont revokés pour pouvoir les retrouver et autoriser le logout même si l'utilisateur est déjà déconnecté. 

J'ai déjà ouvert une issue sur la lib, mais le fix ne sera sans doute pas trivial et provoquera sans doute des discussions :)
En attendant on corrige de notre côté 

