### PR TITLE
Send logs to ElasticSearch

### DIFF
--- a/inclusion_connect/logging.py
+++ b/inclusion_connect/logging.py
@@ -1,3 +1,8 @@
+import logging.handlers
+import threading
+
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import bulk
 from pythonjsonlogger import jsonlogger
 
 from inclusion_connect.utils.oidc import oidc_params
@@ -22,3 +27,48 @@ class JsonFormatter(jsonlogger.JsonFormatter):
         super().add_fields(log_record, record, message_dict)
         for record_attr in ["name", "levelname"]:
             log_record[record_attr] = getattr(record, record_attr)
+
+
+class ElasticSearchHandler(logging.handlers.BufferingHandler):
+    timer = None
+
+    def __init__(  # noqa: PLR0913 Too many arguments to function call.
+        self,
+        *,
+        capacity,
+        send_after_inactive_for_secs=2.0,
+        host,
+        index_name,
+        es_timeout_secs=5,
+    ):
+        """
+        Inspired from https://github.com/cmanaha/python-elasticsearch-logger/blob/master/cmreslogging/handlers.py.
+
+        :param int capacity: Max number of log records before sending to ElasticSearch.
+        :param float send_after_inactive_for_secs: Send to ElasticSearch if no records
+            are emitted in send_after_inactive_for_secs seconds.
+        """
+        super().__init__(capacity)
+        self.send_after_inactive_for_secs = send_after_inactive_for_secs
+        self.es_client = Elasticsearch(host, http_compress=True, request_timeout=es_timeout_secs, max_retries=10)
+        self.index_name = index_name
+
+    def emit(self, record):
+        if self.timer and self.timer.is_alive():
+            self.timer.cancel()
+        formatted_record = self.format(record)
+        super().emit(formatted_record)
+        self.timer = threading.Timer(self.send_after_inactive_for_secs, self.flush)
+        self.timer.start()
+
+    def send_to_elastic(self, log_buffer):
+        actions = ({"_source": log} for log in log_buffer)
+        bulk(client=self.es_client, actions=actions, index=self.index_name, stats_only=True)
+
+    def flush(self):
+        with self.lock:
+            log_buffer = self.buffer
+            self.buffer = []
+        if log_buffer:
+            t = threading.Thread(target=self.send_to_elastic, args=(log_buffer,), daemon=False)
+            t.start()

--- a/inclusion_connect/settings/dev.py
+++ b/inclusion_connect/settings/dev.py
@@ -48,3 +48,8 @@ DATABASES["default"]["PORT"] = os.getenv("PGPORT", "5433")  # noqa: F405
 DATABASES["default"]["NAME"] = os.getenv("PGDATABASE", "inclusion_connect")  # noqa: F405
 DATABASES["default"]["USER"] = os.getenv("PGUSER", "postgres")  # noqa: F405
 DATABASES["default"]["PASSWORD"] = os.getenv("PGPASSWORD", "password")  # noqa: F405
+
+try:
+    LOGGING["loggers"]["inclusion_connect"]["handlers"].remove("elasticsearch")  # noqa: F405
+except ValueError:
+    pass

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -37,5 +37,6 @@ python-dotenv  # https://github.com/theskumar/python-dotenv
 # Production requirements
 # ------------------------------------------------------------------------------
 uwsgi==2.0.*  # https://github.com/unbit/uwsgi
+elasticsearch==8.*
 sentry-sdk  # https://github.com/getsentry/sentry-python
 python-json-logger  # https://github.com/madzak/python-json-logger

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,7 @@ certifi==2023.5.7 \
     --hash=sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7 \
     --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
     # via
+    #   elastic-transport
     #   requests
     #   sentry-sdk
 cffi==1.15.1 \
@@ -223,6 +224,14 @@ django-oauth-toolkit==2.3.0 \
     --hash=sha256:47dfeab97ec21496f307c2cf3468e64ca08897fa499bf3104366d32005c9111d \
     --hash=sha256:cf1cb1a5744672e6bd7d66b4a110a463bcef9cf5ed4f27e29682cc6a4d0df1ed
     # via -r requirements/base.in
+elastic-transport==8.4.0 \
+    --hash=sha256:19db271ab79c9f70f8c43f8f5b5111408781a6176b54ab2e54d713b6d9ceb815 \
+    --hash=sha256:b9ad708ceb7fcdbc6b30a96f886609a109f042c0b9d9f2e44403b3133ba7ff10
+    # via elasticsearch
+elasticsearch==8.8.0 \
+    --hash=sha256:2223ee9daaa3c80c25b28ec3f7c48e66fce6b767a338333d9a81886046a07df6 \
+    --hash=sha256:6878313cd598c7c90079fed1d4be72e198da35cba57f4083e6bee91f9c70b0eb
+    # via -r requirements/base.in
 idna==3.4 \
     --hash=sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4 \
     --hash=sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2
@@ -287,11 +296,12 @@ typing-extensions==4.7.0 \
     --hash=sha256:5d8c9dac95c27d20df12fb1d97b9793ab8b2af8a3a525e68c80e21060c161771 \
     --hash=sha256:935ccf31549830cda708b42289d44b6f74084d616a00be651601a4f968e77c82
     # via dj-database-url
-urllib3==2.0.3 \
-    --hash=sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1 \
-    --hash=sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825
+urllib3==1.26.16 \
+    --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \
+    --hash=sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
     # via
     #   django-anymail
+    #   elastic-transport
     #   requests
     #   sentry-sdk
 uwsgi==2.0.21 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -65,6 +65,7 @@ certifi==2023.5.7 \
     --hash=sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716
     # via
     #   -r requirements/base.txt
+    #   elastic-transport
     #   httpcore
     #   httpx
     #   requests
@@ -399,6 +400,16 @@ editorconfig==0.12.3 \
     # via
     #   cssbeautifier
     #   jsbeautifier
+elastic-transport==8.4.0 \
+    --hash=sha256:19db271ab79c9f70f8c43f8f5b5111408781a6176b54ab2e54d713b6d9ceb815 \
+    --hash=sha256:b9ad708ceb7fcdbc6b30a96f886609a109f042c0b9d9f2e44403b3133ba7ff10
+    # via
+    #   -r requirements/base.txt
+    #   elasticsearch
+elasticsearch==8.8.0 \
+    --hash=sha256:2223ee9daaa3c80c25b28ec3f7c48e66fce6b767a338333d9a81886046a07df6 \
+    --hash=sha256:6878313cd598c7c90079fed1d4be72e198da35cba57f4083e6bee91f9c70b0eb
+    # via -r requirements/base.txt
 execnet==1.9.0 \
     --hash=sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
     --hash=sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142
@@ -851,12 +862,13 @@ typing-extensions==4.7.0 \
     # via
     #   -r requirements/base.txt
     #   dj-database-url
-urllib3==2.0.3 \
-    --hash=sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1 \
-    --hash=sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825
+urllib3==1.26.16 \
+    --hash=sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f \
+    --hash=sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
     # via
     #   -r requirements/base.txt
     #   django-anymail
+    #   elastic-transport
     #   requests
     #   sentry-sdk
 uwsgi==2.0.21 \

--- a/tests/__snapshots__/test_logging.ambr
+++ b/tests/__snapshots__/test_logging.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_log_formatting[log serialized as JSON with metadata]
   '''
-  {"key": "value", "other_key": "value", "timestamp": "2023-05-05T11:11:11Z", "name": "inclusion_connect", "levelname": "INFO"}
+  {"key": "value", "other_key": "value", "@timestamp": "2023-05-05T11:11:11Z", "name": "inclusion_connect", "levelname": "INFO"}
   INFO:inclusion_connect:{'key': 'value', 'other_key': 'value'}
   
   '''

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,9 @@
 import logging
+from unittest import mock
 
 from freezegun import freeze_time
+
+from inclusion_connect.logging import ElasticSearchHandler
 
 
 @freeze_time("2023-05-05 11:11:11")
@@ -11,3 +14,32 @@ def test_log_formatting(snapshot):
     stream = handler.stream
     stream.seek(0)
     assert stream.read() == snapshot(name="log serialized as JSON with metadata")
+
+
+@mock.patch("inclusion_connect.logging.bulk")
+class TestElasticSearchHandler:
+    def test_elastic_search_handler_sends_at_capacity(self, bulk_mock):
+        handler = ElasticSearchHandler(capacity=1, index_name="test", host="https://localhost:9200")
+        handler.handle(logging.LogRecord("test_logger", logging.INFO, "pathname", 1, "msg", (), None))
+        bulk_mock.assert_called_once()
+        handler.timer.cancel()
+
+    def test_elastic_search_handler_after_some_time(self, bulk_mock):
+        handler = ElasticSearchHandler(
+            capacity=100,
+            index_name="test",
+            host="https://localhost:9200",
+            send_after_inactive_for_secs=0,
+        )
+        handler.handle(logging.LogRecord("test_logger", logging.INFO, "pathname", 1, "msg", (), None))
+
+        # This might be a bit fragile: the timer thread may execute before the next assertion.
+        # That’s unlikely, considering the amount of work the timer thread has compared to the test thread,
+        # and thousands runs do not show flakiness.
+        # Keeping the assertion makes the test easier to follow and more robust.
+        bulk_mock.assert_not_called()
+
+        timer_internal_event = handler.timer.finished
+        # Wait for the timer thread to complete, and verify wait did not timeout.
+        assert timer_internal_event.wait(1) is True
+        bulk_mock.assert_called_once()


### PR DESCRIPTION
Logs are buffered by the application, and sent either:
- when the buffer is full, or
- after 5 seconds without logs

`flush()` does not send synchronously to ElasticSearch, to avoid
blocking on `emit()` (which calls `flush()` synchronously when capacity
is reached).

The `send_after_inactive_for_secs` is purposely not too large, to
increase the chances of flushing before the new logs come in. In the
worst case, with a capacity of 500, the logs can be retained 500 * 2s =
1000 seconds (a bit more than 15 minutes).

The Elasticsearch client implements a power of 2 backoff. With 10 max
retries, the app will wait for at 2^11-1 = 2047 seconds for
ElasticSearch to be back.