### PR TITLE
Améliorations du parcours de vérification d'email modifié depuis l'espace personnel

### DIFF
--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -225,7 +225,7 @@ class ConfirmEmailView(TemplateView):
         try:
             self.email_address = EmailAddress.objects.get(email=request.session[EMAIL_CONFIRM_KEY], verified_at=None)
         except (KeyError, EmailAddress.DoesNotExist):
-            return HttpResponseRedirect(reverse("accounts:edit_user_info"))
+            return HttpResponseRedirect(reverse("accounts:edit_user_info") + "?" + self.request.GET.urlencode())
         return super().dispatch(request, *args, **kwargs)
 
     def post(self, request):
@@ -235,7 +235,7 @@ class ConfirmEmailView(TemplateView):
         log["event"] = self.EVENT_NAME
         log["user"] = self.email_address.user_id
         transaction.on_commit(partial(logger.info, log))
-        return HttpResponseRedirect(reverse("accounts:confirm-email"))
+        return HttpResponseRedirect(self.request.get_full_path())
 
 
 def handle_email_confirmation(request, user_id, email):
@@ -424,7 +424,7 @@ class EditUserInfoView(MyAccountMixin, UpdateView):
             emails.send_verification_email(self.request, email_address)
             self.request.session[EMAIL_CONFIRM_KEY] = email
             user.save_next_redirect_uri(self.request.get_full_path())
-            return HttpResponseRedirect(reverse("accounts:confirm-email"))
+            return HttpResponseRedirect(reverse("accounts:confirm-email") + "?" + self.request.GET.urlencode())
         if form.changed_data:
             messages.success(self.request, "Vos informations personnelles ont été mises à jour.")
         return response

--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -221,12 +221,12 @@ class ConfirmEmailView(TemplateView):
     template_name = "email_confirmation.html"
     EVENT_NAME = "send_verification_email"
 
-    def setup(self, request, *args, **kwargs):
-        super().setup(request, *args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
         try:
             self.email_address = EmailAddress.objects.get(email=request.session[EMAIL_CONFIRM_KEY], verified_at=None)
-        except (KeyError, EmailAddress.DoesNotExist) as e:
-            raise Http404 from e
+        except (KeyError, EmailAddress.DoesNotExist):
+            return HttpResponseRedirect(reverse("accounts:edit_user_info"))
+        return super().dispatch(request, *args, **kwargs)
 
     def post(self, request):
         messages.success(request, "E-mail de vérification envoyé.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,6 @@ ignore="H006,H014,H017,H023,H030,H031,T002,T003"
 custom_blocks="buttons,endbuttons"
 max_attribute_length=200
 preserve_blank_lines=true
+
+[tool.ruff.extend-per-file-ignores]
+"tests/*" = ["PLR0915"]  # pylint too-many-statements

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -1203,14 +1203,16 @@ def test_new_terms(caplog, client, terms_accepted_at):
 
 class TestConfirmEmailView:
     def test_get_anonymous(self, client):
-        response = client.get(reverse("accounts:confirm-email"))
-        assert response.status_code == 404
+        response = client.get(reverse("accounts:confirm-email"), follow=True)
+        assertRedirects(
+            response, add_url_params(reverse("accounts:login"), {"next": reverse("accounts:edit_user_info")})
+        )
 
     def test_get_with_confirmed_email(self, client):
         user = UserFactory()
         client.force_login(user)
         response = client.get(reverse("accounts:confirm-email"))
-        assert response.status_code == 404
+        assertRedirects(response, reverse("accounts:edit_user_info"))
 
     def test_get(self, client, snapshot):
         user = UserFactory(email="")

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -995,7 +995,7 @@ class TestEditUserInfoView:
             edit_user_info_url,
             data={"last_name": "Doe", "first_name": "John", "email": "jo-with-typo@email.com"},
         )
-        assertRedirects(response, reverse("accounts:confirm-email"))
+        assertRedirects(response, add_url_params(reverse("accounts:confirm-email"), {"referrer_uri": "rp_url"}))
         user.refresh_from_db()
         assert user.first_name == "John"
         assert user.last_name == "Doe"
@@ -1027,7 +1027,7 @@ class TestEditUserInfoView:
             edit_user_info_url,
             data={"last_name": "Doe", "first_name": "John", "email": "joe@email.com"},
         )
-        assertRedirects(response, reverse("accounts:confirm-email"))
+        assertRedirects(response, add_url_params(reverse("accounts:confirm-email"), {"referrer_uri": "rp_url"}))
         user.refresh_from_db()
         assert user.first_name == "John"
         assert user.last_name == "Doe"


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Je-demande-le-renvoi-d-un-email-alors-qu-email-valid-cran-bug-ad1ccf61d94745e49a23ac34e3591ce4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Gestion plus souple des erreurs du formulaire de renvois d'email de confirmation:
Si on ne trouve pas l'email à confirmer, on redirige vers l'espace personnel en indiquant que l'email est déjà validé. 

Meilleur gestion du bouton de redirection vers le partenaire en conservant le lien en session 

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

