### PR TITLE
Permettre de se connecter à l'admin avec un email de plus de 32 caractères

### DIFF
--- a/inclusion_connect/admin/apps.py
+++ b/inclusion_connect/admin/apps.py
@@ -1,0 +1,5 @@
+from django.contrib.admin import apps as admin_apps
+
+
+class AdminConfig(admin_apps.AdminConfig):
+    default_site = "inclusion_connect.admin.sites.AdminSite"

--- a/inclusion_connect/admin/sites.py
+++ b/inclusion_connect/admin/sites.py
@@ -1,0 +1,14 @@
+from django.contrib.admin import forms as admin_forms, sites as admin_sites
+
+from inclusion_connect.users.models import User
+
+
+class AdminAuthenticationForm(admin_forms.AdminAuthenticationForm):
+    def __init__(self, request=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["username"].widget.attrs["maxlength"] = User._meta.get_field("email").max_length
+        self.fields["username"].label = "Adresse e-mail"
+
+
+class AdminSite(admin_sites.AdminSite):
+    login_form = AdminAuthenticationForm

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -39,7 +39,6 @@ DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "Inclusion Connect <contact
 # Application definition
 
 DJANGO_APPS = [
-    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
@@ -55,6 +54,7 @@ THIRD_PARTY_APPS = [
 ]
 
 LOCAL_APPS = [
+    "inclusion_connect.admin.apps.AdminConfig",
     "inclusion_connect.keycloak_compat",
     "inclusion_connect.oidc_overrides",
     "inclusion_connect.users",

--- a/tests/__snapshots__/test_admin.ambr
+++ b/tests/__snapshots__/test_admin.ambr
@@ -1,0 +1,21 @@
+# serializer version: 1
+# name: test_login_form
+  '''
+  <form action="/admin/login/" id="login-form" method="post"><input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+    <div class="form-row">
+      
+      <label class="required" for="id_username">Adresse e-mail :</label> <input autocapitalize="none" autocomplete="username" autofocus="" id="id_username" maxlength="32" name="username" required="" type="text"/>
+    </div>
+    <div class="form-row">
+      
+      <label class="required" for="id_password">Mot de passe :</label> <input autocomplete="current-password" id="id_password" name="password" required="" type="password"/>
+      <input name="next" type="hidden" value="/admin/"/>
+    </div>
+    
+    
+    <div class="submit-row">
+      <input type="submit" value="Connexion"/>
+    </div>
+  </form>
+  '''
+# ---

--- a/tests/__snapshots__/test_admin.ambr
+++ b/tests/__snapshots__/test_admin.ambr
@@ -4,7 +4,7 @@
   <form action="/admin/login/" id="login-form" method="post"><input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
     <div class="form-row">
       
-      <label class="required" for="id_username">Adresse e-mail :</label> <input autocapitalize="none" autocomplete="username" autofocus="" id="id_username" maxlength="32" name="username" required="" type="text"/>
+      <label class="required" for="id_username">Adresse e-mail :</label> <input autocapitalize="none" autocomplete="username" autofocus="" id="id_username" maxlength="254" name="username" required="" type="text"/>
     </div>
     <div class="form-row">
       

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,8 @@
+from django.urls import reverse
+
+from tests.helpers import parse_response_to_soup
+
+
+def test_login_form(client, snapshot):
+    response = client.get(reverse("admin:login"))
+    assert str(parse_response_to_soup(response, selector="#login-form")) == snapshot


### PR DESCRIPTION
### Pourquoi ?

User.username est un UUIDFIeld (max 32 chars) donc le formulaire utilise cette longueur même si derrière on compare à l'email.
