### PR TITLE
Don’t upgrade packages on make compile-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 
 venv: $(VIRTUAL_ENV)
 
-PIP_COMPILE_FLAGS := --upgrade --allow-unsafe --generate-hashes
+PIP_COMPILE_FLAGS := --allow-unsafe --generate-hashes
 compile-deps: $(VIRTUAL_ENV)
 	pip-compile $(PIP_COMPILE_FLAGS) -o requirements/base.txt requirements/base.in
 	pip-compile $(PIP_COMPILE_FLAGS) -o requirements/dev.txt requirements/dev.in


### PR DESCRIPTION
The main use case is to add a dependency, since dependabot handles the
upgrade. When adding a dependency, only the added dependency should be
changed in the requirements.txt.