### PR TITLE
Mise à jour des permissions du groupe support

### DIFF
--- a/inclusion_connect/users/apps.py
+++ b/inclusion_connect/users/apps.py
@@ -18,12 +18,8 @@ def ensure_support_group(*args, **kwargs):
     group.permissions.set(
         Permission.objects.filter(
             codename__in=[
-                "add_user",
                 "change_user",
                 "view_user",
-                "add_emailaddress",
-                "change_emailaddress",
-                "delete_emailaddress",
                 "view_emailaddress",
                 "view_userapplicationlink",
             ]

--- a/tests/users/test_admin.py
+++ b/tests/users/test_admin.py
@@ -580,7 +580,7 @@ class TestUserAdmin:
         assert response.status_code == 200
 
         response = client.get(reverse("admin:users_user_add"))
-        assert response.status_code == 200
+        assert response.status_code == 403
 
         response = client.get(reverse("admin:users_user_change", args=(user.pk,)))
         assert response.status_code == 200


### PR DESCRIPTION
On ne veut pas permettre de créer des utilisateurs depuis l'admin par le support : les seuls utilisateurs que l'on veut créer de cette manière sont les membres du support et/ou superadmin. Action qui sera faite par des superadmin

