### PR TITLE
Amélioration des logs / stats

### DIFF
--- a/inclusion_connect/oidc_overrides/views.py
+++ b/inclusion_connect/oidc_overrides/views.py
@@ -13,7 +13,6 @@ from oauth2_provider.settings import oauth2_settings
 
 from inclusion_connect.logging import log_data
 from inclusion_connect.oidc_overrides.models import Application
-from inclusion_connect.stats.models import Actions, Stats
 from inclusion_connect.users.models import UserApplicationLink
 from inclusion_connect.utils.oidc import OIDC_SESSION_KEY, get_next_url, initial_from_login_hint
 from inclusion_connect.utils.urls import is_inclusion_connect_url
@@ -77,12 +76,6 @@ class BaseAuthorizationView(OIDCSessionMixin, oauth2_views.base.AuthorizationVie
             application=application,
             defaults={"last_login": timezone.now()},
         )
-        Stats.objects.get_or_create(
-            user=self.request.user,
-            application=application,
-            date=timezone.localdate().replace(day=1),
-            action=self.action,
-        )
         return response
 
     def redirect(self, redirect_to, application):
@@ -99,17 +92,14 @@ class BaseAuthorizationView(OIDCSessionMixin, oauth2_views.base.AuthorizationVie
 
 class AuthorizationView(BaseAuthorizationView):
     login_url = reverse_lazy("accounts:login")
-    action = Actions.LOGIN
 
 
 class RegistrationView(BaseAuthorizationView):
     login_url = reverse_lazy("accounts:register")
-    action = Actions.REGISTER
 
 
 class ActivationView(BaseAuthorizationView):
     login_url = reverse_lazy("accounts:activate")
-    action = Actions.REGISTER
 
 
 original_validate_logout_request = oauth2_views.oidc.validate_logout_request

--- a/inclusion_connect/stats/helpers.py
+++ b/inclusion_connect/stats/helpers.py
@@ -1,0 +1,25 @@
+from functools import lru_cache
+
+from django.utils import timezone
+
+from inclusion_connect.oidc_overrides.models import Application
+from inclusion_connect.stats.models import Stats
+from inclusion_connect.utils.oidc import oidc_params
+
+
+@lru_cache
+def get_application(request, next_url=None):
+    try:
+        return Application.objects.get(client_id=oidc_params(request, next_url)["client_id"])
+    except KeyError:
+        return None
+
+
+def account_action(user, action, request, next_url=None):
+    if application := get_application(request, next_url):
+        Stats.objects.get_or_create(
+            user=user,
+            application=application,
+            date=timezone.localdate().replace(day=1),
+            action=action,
+        )

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -792,7 +792,12 @@ class TestPasswordResetView:
                     "inclusion_connect.auth",
                     logging.INFO,
                     "{'ip_address': '127.0.0.1', 'event': 'reset_password', 'user': UUID('%s')}" % user.pk,
-                )
+                ),
+                (
+                    "inclusion_connect.auth",
+                    logging.INFO,
+                    "{'ip_address': '127.0.0.1', 'event': 'login', 'user': UUID('%s')}" % user.pk,
+                ),
             ]
 
     def test_password_reset_unknown_email(self, caplog, client):
@@ -899,7 +904,12 @@ class TestPasswordResetView:
                 "inclusion_connect.auth",
                 logging.INFO,
                 "{'ip_address': '127.0.0.1', 'event': 'reset_password', 'user': UUID('%s')}" % user.pk,
-            )
+            ),
+            (
+                "inclusion_connect.auth",
+                logging.INFO,
+                "{'ip_address': '127.0.0.1', 'event': 'login', 'user': UUID('%s')}" % user.pk,
+            ),
         ]
 
 
@@ -1282,7 +1292,15 @@ class TestConfirmEmailTokenView:
                 "'email': 'me@mailinator.com', "
                 f"'user': UUID('{user.pk}'), "
                 "'event': 'confirm_email_address'}",
-            )
+            ),
+            (
+                "inclusion_connect.auth",
+                logging.INFO,
+                "{'ip_address': '127.0.0.1', "
+                "'email': 'me@mailinator.com', "
+                f"'user': UUID('{user.pk}'), "
+                "'event': 'login'}",
+            ),
         ]
         caplog.clear()
 
@@ -1338,7 +1356,16 @@ class TestConfirmEmailTokenView:
                 f"'user': UUID('{user.pk}'), "
                 "'event': 'confirm_email_address', "
                 "'application': 'my_application'}",
-            )
+            ),
+            (
+                "inclusion_connect.auth",
+                logging.INFO,
+                "{'ip_address': '127.0.0.1', "
+                "'email': 'me@mailinator.com', "
+                f"'user': UUID('{user.pk}'), "
+                "'event': 'login', "
+                "'application': 'my_application'}",
+            ),
         ]
 
     @freeze_time("2023-04-26 11:11:11")
@@ -1501,7 +1528,15 @@ class TestConfirmEmailTokenView:
                 "'email': 'new@mailinator.com', "
                 f"'user': UUID('{user.pk}'), "
                 "'event': 'confirm_email_address'}",
-            )
+            ),
+            (
+                "inclusion_connect.auth",
+                logging.INFO,
+                "{'ip_address': '127.0.0.1', "
+                "'email': 'new@mailinator.com', "
+                f"'user': UUID('{user.pk}'), "
+                "'event': 'login'}",
+            ),
         ]
         caplog.clear()
 

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -28,6 +28,7 @@ from inclusion_connect.utils.oidc import OIDC_SESSION_KEY
 from inclusion_connect.utils.urls import add_url_params
 from tests.asserts import assertMessages
 from tests.helpers import parse_response_to_soup
+from tests.oidc_overrides.factories import ApplicationFactory
 from tests.users.factories import DEFAULT_PASSWORD, EmailAddressFactory, UserFactory
 
 
@@ -1312,6 +1313,7 @@ class TestConfirmEmailTokenView:
     @freeze_time("2023-04-26 11:11:11")
     def test_confirm_email_from_other_client(self, caplog, client, oidc_params):
         user = UserFactory(email="")
+        ApplicationFactory(client_id=oidc_params["client_id"])
         email = "me@mailinator.com"
         email_address = EmailAddress.objects.create(email=email, user_id=user.pk)
         token = email_verification_token(email)

--- a/tests/asserts.py
+++ b/tests/asserts.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, NamedTuple
 
 from django.contrib.messages import DEFAULT_LEVELS, get_messages
@@ -18,3 +19,15 @@ def assertMessages(response: HttpResponse, expected_messages: List[Message]):
         msg_levelname = LEVEL_TO_NAME.get(message.level, message.level)
         expected_levelname = LEVEL_TO_NAME.get(expected_level, expected_level)
         assert (msg_levelname, message.message) == (expected_levelname, expected_msg)
+
+
+def assertRecords(caplog, logger, logs, i=0):
+    assert caplog.record_tuples[i:] == [
+        (
+            logger,
+            logging.INFO,
+            str({"ip_address": "127.0.0.1"} | log),
+        )
+        for log in logs
+    ]
+    caplog.clear()

--- a/tests/keycloak_compat/tests.py
+++ b/tests/keycloak_compat/tests.py
@@ -278,7 +278,15 @@ class TestActionToken:
                 "'email': 'me@mailinator.com', "
                 f"'user': UUID('{user.pk}'), "
                 "'event': 'confirm_email_address'}",
-            )
+            ),
+            (
+                "inclusion_connect.auth",
+                logging.INFO,
+                "{'ip_address': '127.0.0.1', "
+                "'email': 'me@mailinator.com', "
+                f"'user': UUID('{user.pk}'), "
+                "'event': 'login'}",
+            ),
         ]
         caplog.clear()
 
@@ -457,7 +465,15 @@ class TestActionToken:
                 "'email': 'me@mailinator.com', "
                 f"'user': UUID('{user.pk}'), "
                 "'event': 'confirm_email_address'}",
-            )
+            ),
+            (
+                "inclusion_connect.auth",
+                logging.INFO,
+                "{'ip_address': '127.0.0.1', "
+                "'email': 'me@mailinator.com', "
+                f"'user': UUID('{user.pk}'), "
+                "'event': 'login'}",
+            ),
         ]
 
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -9,7 +9,6 @@ from django.contrib.auth import get_user
 from django.core import mail
 from django.db.models import F
 from django.urls import reverse
-from django.utils import timezone
 from freezegun import freeze_time
 from pytest_django.asserts import assertContains, assertQuerySetEqual, assertRedirects
 
@@ -128,8 +127,11 @@ def test_register_endpoint(auth_url, caplog, client, oidc_params, mailoutbox):
     ]
     caplog.clear()
     assertQuerySetEqual(
-        Stats.objects.values_list("date", "user", "application", "action"),
-        [(datetime.date(2023, 5, 1), user.pk, application.pk, "register")],
+        Stats.objects.values_list("date", "user", "application", "action").order_by("action"),
+        [
+            (datetime.date(2023, 5, 1), user.pk, application.pk, "login"),
+            (datetime.date(2023, 5, 1), user.pk, application.pk, "register"),
+        ],
     )
 
     oidc_flow_followup(client, auth_response_params, user, oidc_params, caplog)
@@ -227,13 +229,17 @@ def test_register_endpoint_confirm_email_from_other_client(caplog, client, oidc_
     ]
     caplog.clear()
     assertQuerySetEqual(
-        Stats.objects.values_list("date", "user", "application", "action"),
-        [(datetime.date(2023, 5, 1), user.pk, application.pk, "register")],
+        Stats.objects.values_list("date", "user", "application", "action").order_by("action"),
+        [
+            (datetime.date(2023, 5, 1), user.pk, application.pk, "login"),
+            (datetime.date(2023, 5, 1), user.pk, application.pk, "register"),
+        ],
     )
 
     oidc_flow_followup(other_client, auth_response_params, user, oidc_params, caplog)
 
 
+@freeze_time("2023-05-05 11:11:11")
 @pytest.mark.parametrize("use_other_client", [True, False])
 def test_register_endpoint_email_not_received(caplog, client, oidc_params, use_other_client):
     application = ApplicationFactory(client_id=oidc_params["client_id"])
@@ -365,8 +371,11 @@ def test_register_endpoint_email_not_received(caplog, client, oidc_params, use_o
     ]
     caplog.clear()
     assertQuerySetEqual(
-        Stats.objects.values_list("date", "user", "application", "action"),
-        [(timezone.localdate().replace(day=1), user.pk, application.pk, "register")],
+        Stats.objects.values_list("date", "user", "application", "action").order_by("action"),
+        [
+            (datetime.date(2023, 5, 1), user.pk, application.pk, "login"),
+            (datetime.date(2023, 5, 1), user.pk, application.pk, "register"),
+        ],
     )
 
     oidc_flow_followup(other_client, auth_response_params, user, oidc_params, caplog)
@@ -481,13 +490,17 @@ def test_activate_endpoint(auth_url, caplog, client, oidc_params, mailoutbox):
     ]
     caplog.clear()
     assertQuerySetEqual(
-        Stats.objects.values_list("date", "user", "application", "action"),
-        [(datetime.date(2023, 5, 1), user.pk, application.pk, "register")],
+        Stats.objects.values_list("date", "user", "application", "action").order_by("action"),
+        [
+            (datetime.date(2023, 5, 1), user.pk, application.pk, "login"),
+            (datetime.date(2023, 5, 1), user.pk, application.pk, "register"),
+        ],
     )
 
     oidc_flow_followup(client, auth_response_params, user, oidc_params, caplog)
 
 
+@freeze_time("2023-05-05 11:11:11")
 @pytest.mark.parametrize(
     "auth_url",
     [
@@ -549,12 +562,13 @@ def test_login_endpoint(auth_url, caplog, client, oidc_params):
     caplog.clear()
     assertQuerySetEqual(
         Stats.objects.values_list("date", "user", "application", "action"),
-        [(timezone.localdate().replace(day=1), user.pk, application.pk, "login")],
+        [(datetime.date(2023, 5, 1), user.pk, application.pk, "login")],
     )
 
     oidc_flow_followup(client, auth_response_params, user, oidc_params, caplog)
 
 
+@freeze_time("2023-05-05 11:11:11")
 def test_login_after_password_reset(caplog, client, oidc_params):
     application = ApplicationFactory(client_id=oidc_params["client_id"])
     user = UserFactory()
@@ -631,12 +645,13 @@ def test_login_after_password_reset(caplog, client, oidc_params):
     caplog.clear()
     assertQuerySetEqual(
         Stats.objects.values_list("date", "user", "application", "action"),
-        [(timezone.localdate().replace(day=1), user.pk, application.pk, "login")],
+        [(datetime.date(2023, 5, 1), user.pk, application.pk, "login")],
     )
 
     oidc_flow_followup(client, auth_response_params, user, oidc_params, caplog)
 
 
+@freeze_time("2023-05-05 11:11:11")
 def test_login_after_password_reset_other_client(caplog, client, oidc_params):
     application = ApplicationFactory(client_id=oidc_params["client_id"])
     user = UserFactory()
@@ -716,7 +731,7 @@ def test_login_after_password_reset_other_client(caplog, client, oidc_params):
     caplog.clear()
     assertQuerySetEqual(
         Stats.objects.values_list("date", "user", "application", "action"),
-        [(timezone.localdate().replace(day=1), user.pk, application.pk, "login")],
+        [(datetime.date(2023, 5, 1), user.pk, application.pk, "login")],
     )
 
     oidc_flow_followup(other_client, auth_response_params, user, oidc_params, caplog)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -103,7 +103,16 @@ def test_register_endpoint(auth_url, caplog, client, oidc_params, mailoutbox):
             "'email': 'email@mailinator.com', "
             f"'user': UUID('{user.pk}'), "
             "'event': 'confirm_email_address'}",
-        )
+        ),
+        (
+            "inclusion_connect.auth",
+            logging.INFO,
+            "{'ip_address': '127.0.0.1', "
+            "'application': 'my_application', "
+            "'email': 'email@mailinator.com', "
+            f"'user': UUID('{user.pk}'), "
+            "'event': 'login'}",
+        ),
     ]
     caplog.clear()
 
@@ -196,16 +205,23 @@ def test_register_endpoint_confirm_email_from_other_client(caplog, client, oidc_
         (
             "inclusion_connect.auth",
             logging.INFO,
-            # 'application' not available, OIDC params were stored in session,
-            # and users lose their sessions when changing browsers.
-            # It is simply nice to have, a best effort solution is OK.
             "{'ip_address': '127.0.0.1', "
             f"'email': '{user_email}', "
             f"'user': UUID('{user.pk}'), "
             "'event': 'confirm_email_address', "
             "'application': 'my_application'"
             "}",
-        )
+        ),
+        (
+            "inclusion_connect.auth",
+            logging.INFO,
+            "{'ip_address': '127.0.0.1', "
+            f"'email': '{user_email}', "
+            f"'user': UUID('{user.pk}'), "
+            "'event': 'login', "
+            "'application': 'my_application'"
+            "}",
+        ),
     ]
     caplog.clear()
 
@@ -465,7 +481,20 @@ def test_activate_endpoint(auth_url, caplog, client, oidc_params, mailoutbox):
             f"'user': UUID('{user.pk}'), "
             "'event': 'confirm_email_address'"
             "}",
-        )
+        ),
+        (
+            "inclusion_connect.auth",
+            logging.INFO,
+            # 'application' not available, OIDC params were stored in session,
+            # and users lose their sessions when changing browsers.
+            # It is simply nice to have, a best effort solution is OK.
+            "{'ip_address': '127.0.0.1', "
+            "'application': 'my_application', "
+            "'email': 'email@mailinator.com', "
+            f"'user': UUID('{user.pk}'), "
+            "'event': 'login'"
+            "}",
+        ),
     ]
     caplog.clear()
 
@@ -621,7 +650,15 @@ def test_login_after_password_reset(caplog, client, oidc_params):
             "'application': 'my_application', "
             "'event': 'reset_password', "
             "'user': UUID('%s')}" % user.pk,
-        )
+        ),
+        (
+            "inclusion_connect.auth",
+            logging.INFO,
+            "{'ip_address': '127.0.0.1', "
+            "'application': 'my_application', "
+            "'event': 'login', "
+            "'user': UUID('%s')}" % user.pk,
+        ),
     ]
     caplog.clear()
 
@@ -702,12 +739,19 @@ def test_login_after_password_reset_other_client(caplog, client, oidc_params):
         (
             "inclusion_connect.auth",
             logging.INFO,
-            "{'ip_address': '127.0.0.1', 'application': 'my_application', 'event': 'reset_password', "
-            # 'application' not available, OIDC params were stored in session,
-            # and users lose their sessions when changing browsers.
-            # It is simply nice to have, a best effort solution is OK.
+            "{'ip_address': '127.0.0.1', "
+            "'application': 'my_application', "
+            "'event': 'reset_password', "
             "'user': UUID('%s')}" % user.pk,
-        )
+        ),
+        (
+            "inclusion_connect.auth",
+            logging.INFO,
+            "{'ip_address': '127.0.0.1', "
+            "'application': 'my_application', "
+            "'event': 'login', "
+            "'user': UUID('%s')}" % user.pk,
+        ),
     ]
     caplog.clear()
 
@@ -1172,7 +1216,15 @@ def test_edit_user_info_and_password(caplog, client, mailoutbox):  # noqa: PLR09
             "'email': 'my@email.com', "
             f"'user': UUID('{user.pk}'), "
             "'event': 'confirm_email_address'}",
-        )
+        ),
+        (
+            "inclusion_connect.auth",
+            logging.INFO,
+            "{'ip_address': '127.0.0.1', "
+            "'email': 'my@email.com', "
+            f"'user': UUID('{user.pk}'), "
+            "'event': 'login'}",
+        ),
     ]
     caplog.clear()
 
@@ -1299,7 +1351,15 @@ def test_edit_user_info_other_client(caplog, client, oidc_params, mailoutbox):
             "'email': 'my@email.com', "
             f"'user': UUID('{user.pk}'), "
             "'event': 'confirm_email_address'}",
-        )
+        ),
+        (
+            "inclusion_connect.auth",
+            logging.INFO,
+            "{'ip_address': '127.0.0.1', "
+            "'email': 'my@email.com', "
+            f"'user': UUID('{user.pk}'), "
+            "'event': 'login'}",
+        ),
     ]
     caplog.clear()
 

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,39 @@
+import datetime
+
+from freezegun import freeze_time
+from pytest_django.asserts import assertQuerySetEqual
+
+from inclusion_connect.stats.helpers import account_action
+from inclusion_connect.stats.models import Actions, Stats
+from tests.oidc_overrides.factories import ApplicationFactory
+from tests.users.factories import UserFactory
+
+
+def test_stats(mocker):
+    application_1 = ApplicationFactory(client_id="00000000-0000-0000-0000-000000000000")
+    application_2 = ApplicationFactory(client_id="11111111-1111-1111-1111-111111111111")
+    user = UserFactory()
+
+    with freeze_time("2023-04-27 14:06"):
+        mocker.patch("inclusion_connect.stats.helpers.get_application", return_value=application_1)
+        account_action(user, Actions.LOGIN, None)
+
+    with freeze_time("2023-04-27 14:07"):
+        mocker.patch("inclusion_connect.stats.helpers.get_application", return_value=application_2)
+        account_action(user, Actions.LOGIN, None)
+
+    with freeze_time("2023-04-27 14:08"):
+        mocker.patch("inclusion_connect.stats.helpers.get_application", return_value=application_1)
+        account_action(user, Actions.LOGIN, None)
+    with freeze_time("2023-05-01 00:08"):
+        mocker.patch("inclusion_connect.stats.helpers.get_application", return_value=application_1)
+        account_action(user, Actions.LOGIN, None)
+
+    assertQuerySetEqual(
+        Stats.objects.values_list("date", "user", "application", "action").order_by("date", "application__client_id"),
+        [
+            (datetime.date(2023, 4, 1), user.pk, application_1.pk, "login"),
+            (datetime.date(2023, 4, 1), user.pk, application_2.pk, "login"),
+            (datetime.date(2023, 5, 1), user.pk, application_1.pk, "login"),
+        ],
+    )


### PR DESCRIPTION
- correction des stats qui se basaient sur l'url d'arrivée pour logger un register/login (ce qui est faux)
- Ajout de LOGIN manquant dans les logs ES (reset mot de passe et verification d’e-mail)
- Ajouter l'application aux log de l'espace personnel (au lieu des paramètres)
- ajouter un helper pour utiliser un dictionnaire pour tester les logs