### PR TITLE
Amélioration de la page d'activation

### DIFF
--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -114,7 +114,9 @@ class ActivateAccountView(BaseUserCreationView):
         # Check user info is provided
         try:
             self.get_user_info()
-        except KeyError:
+            params = oidc_params(self.request)
+            self.application = Application.objects.get(client_id=params["client_id"])
+        except (KeyError, Application.DoesNotExist):
             return render(
                 request,
                 "oidc_authorize.html",
@@ -133,8 +135,7 @@ class ActivateAccountView(BaseUserCreationView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        # TODO Get oauth2 application name from client_id
-        return context | {"application_name": "Les emplois de l'inclusion"} | self.get_user_info()
+        return context | {"application_name": self.application.name} | self.get_user_info()
 
     def get_initial(self):
         return super().get_initial() | self.get_user_info()

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -540,6 +540,7 @@ class TestRegisterView:
 
 class TestActivateAccountView:
     def test_activate_account(self, caplog, client):
+        application = ApplicationFactory()
         redirect_url = reverse("oauth2_provider:rp-initiated-logout")
         url = add_url_params(reverse("accounts:activate"), {"next": redirect_url})
         user = UserFactory.build(email="me@mailinator.com")
@@ -555,6 +556,7 @@ class TestActivateAccountView:
             "login_hint": user.email,
             "firstname": user.first_name,
             "lastname": user.last_name,
+            "client_id": application.client_id,
         }
         client_session.save()
         response = client.get(url)
@@ -581,10 +583,20 @@ class TestActivateAccountView:
         assert email_address.user_id == email_address.user.pk
         assert email_address.verified_at is None
         assertRecords(
-            caplog, "inclusion_connect.auth", [{"email": "me@mailinator.com", "user": user.pk, "event": "activate"}]
+            caplog,
+            "inclusion_connect.auth",
+            [
+                {
+                    "application": application.client_id,
+                    "email": "me@mailinator.com",
+                    "user": user.pk,
+                    "event": "activate",
+                }
+            ],
         )
 
     def test_email_already_exists(self, caplog, client):
+        application = ApplicationFactory()
         redirect_url = reverse("oauth2_provider:rp-initiated-logout")
         url = add_url_params(reverse("accounts:activate"), {"next": redirect_url})
         user = UserFactory()
@@ -600,6 +612,7 @@ class TestActivateAccountView:
             "login_hint": user.email,
             "firstname": user.first_name,
             "lastname": user.last_name,
+            "client_id": application.client_id,
         }
         client_session.save()
         response = client.get(url)
@@ -630,6 +643,7 @@ class TestActivateAccountView:
             "inclusion_connect.auth",
             [
                 {
+                    "application": application.client_id,
                     "user": user.pk,
                     "event": "activate_error",
                     "errors": {
@@ -653,6 +667,7 @@ class TestActivateAccountView:
         )
 
     def test_email_already_exists_not_verified(self, caplog, client):
+        application = ApplicationFactory()
         redirect_url = reverse("oauth2_provider:rp-initiated-logout")
         url = add_url_params(reverse("accounts:activate"), {"next": redirect_url})
         user = UserFactory(email="")
@@ -664,6 +679,7 @@ class TestActivateAccountView:
             "login_hint": user_email,
             "firstname": user.first_name,
             "lastname": user.last_name,
+            "client_id": application.client_id,
         }
         client_session.save()
         response = client.post(
@@ -691,6 +707,7 @@ class TestActivateAccountView:
             "inclusion_connect.auth",
             [
                 {
+                    "application": application.client_id,
                     "user": user.pk,
                     "event": "activate_error",
                     "errors": {
@@ -714,6 +731,7 @@ class TestActivateAccountView:
         )
 
     def test_terms_are_required(self, caplog, client):
+        application = ApplicationFactory()
         redirect_url = reverse("oauth2_provider:rp-initiated-logout")
         url = add_url_params(reverse("accounts:activate"), {"next": redirect_url})
         user = UserFactory.build()
@@ -723,6 +741,7 @@ class TestActivateAccountView:
             "login_hint": user.email,
             "firstname": user.first_name,
             "lastname": user.last_name,
+            "client_id": application.client_id,
         }
         client_session.save()
 
@@ -744,6 +763,7 @@ class TestActivateAccountView:
             "inclusion_connect.auth",
             [
                 {
+                    "application": application.client_id,
                     "email": user.email,
                     "event": "activate_error",
                     "errors": {"terms_accepted": [{"message": "Ce champ est obligatoire.", "code": "required"}]},

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -380,9 +380,12 @@ def test_activate_endpoint(auth_url, caplog, client, oidc_params, mailoutbox):
     auth_complete_url = add_url_params(auth_url, auth_params)
     response = client.get(auth_complete_url)
     assertRedirects(response, reverse("accounts:activate"))
+    activation_url = response.url
+    response = client.get(activation_url)
+    assertContains(response, f"Vous pouvez réutiliser celui de votre compte sur {application.name}")
 
     response = client.post(
-        response.url,
+        activation_url,
         data={
             "email": user_email,
             "first_name": user.first_name,

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -5,6 +5,7 @@ import pytest
 from django.urls import reverse
 
 from inclusion_connect.utils.oidc import OIDC_SESSION_KEY
+from tests.oidc_overrides.factories import ApplicationFactory
 from tests.users.factories import UserFactory
 
 
@@ -22,7 +23,12 @@ OIDCSessionMixin_accounts: List[OIDCSessionMixinTestInput] = [
     OIDCSessionMixinTestInput(
         False,
         "accounts:activate",
-        {"firstname": "Mercedes", "lastname": "Colomar", "login_hint": "m.c@mailinator.com"},
+        {
+            "firstname": "Mercedes",
+            "lastname": "Colomar",
+            "login_hint": "m.c@mailinator.com",
+            "client_id": "client_id",
+        },
     ),
 ]
 
@@ -45,6 +51,7 @@ class NextUrlExpected:
 class TestOpenRedirectWithNextParameter:
     @pytest.mark.parametrize("view", OIDCSessionMixin_accounts)
     def test_accounts(self, client, testinput, view):
+        ApplicationFactory(client_id="client_id")
         if view.requires_login:
             client.force_login(UserFactory())
         if view.oidc_data:


### PR DESCRIPTION
Utiliser le nom de l'application au lieu de toujours indiquer que l'utilisateur vient des emplois de l'inclusion