### PR TITLE
Bind dockers to [::1]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,14 +15,14 @@ services:
       - postgres_data:/var/lib/postgresql/data
     restart: always
     ports:
-      - "localhost:${POSTGRES_PORT_ON_DOCKER_HOST:-5433}:5432"
+      - "[::1]:${POSTGRES_PORT_ON_DOCKER_HOST:-5433}:5432"
 
   smtp:
     container_name: inclusion_connect_smtp
     image: mailhog/mailhog
     ports:
-      - localhost:1025:1025
-      - localhost:8025:8025
+      - "[::1]:1025:1025"
+      - "[::1]:8025:8025"
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Partially reverts d8211a448ff1da1f5c5a2373afddf2b6fc3f2ba1.

Docker does not accept binding to a hostname, only to IP addresses. If
we must choose one, might as well use IPv6. :)