### PR TITLE
Petites personnalisations de l'admin IC

### DIFF
--- a/inclusion_connect/admin/sites.py
+++ b/inclusion_connect/admin/sites.py
@@ -12,3 +12,7 @@ class AdminAuthenticationForm(admin_forms.AdminAuthenticationForm):
 
 class AdminSite(admin_sites.AdminSite):
     login_form = AdminAuthenticationForm
+
+    site_header = "Administration Inclusion Connect"
+    site_title = "Administration Inclusion Connect"
+    index_title = None


### PR DESCRIPTION
Afficher Administration Inclusion Connect au lieu de "Administration de Django" et retirer un "Site d’administration" inutile dans la page d'index 

https://www.notion.so/plateforme-inclusion/Modifier-titre-admin-django-3a59602466c74e4f8278a31b0e6e11a9?pvs=4