### PR TITLE
Corriger le contenu de l'e'mail de vérification en cas de modification d'adresse e-mail.

### DIFF
--- a/inclusion_connect/accounts/emails.py
+++ b/inclusion_connect/accounts/emails.py
@@ -9,7 +9,7 @@ from inclusion_connect.accounts import tokens
 from inclusion_connect.users.models import EmailAddress
 
 
-def send_verification_email(request: HttpRequest, email_address: EmailAddress):
+def send_verification_email(request: HttpRequest, email_address: EmailAddress, registration=True):
     uidb64 = http.urlsafe_base64_encode(str(email_address.user_id).encode())
     context = {
         "token_url": request.build_absolute_uri(
@@ -20,7 +20,8 @@ def send_verification_email(request: HttpRequest, email_address: EmailAddress):
                     "token": tokens.email_verification_token(email_address.email),
                 },
             )
-        )
+        ),
+        "registration": registration,
     }
     subject = loader.render_to_string("registration/email_verification_subject.txt", context).strip()
     html_email = loader.render_to_string("registration/email_verification_body.html", context)

--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -449,7 +449,7 @@ class EditUserInfoView(MyAccountMixin, UpdateView):
         if user.email != email and not form.email_case_changed(user):
             # Do not hit the database again, we have all necessary information.
             email_address = EmailAddress(user=user, email=email)
-            emails.send_verification_email(self.request, email_address)
+            emails.send_verification_email(self.request, email_address, registration=False)
             self.request.session[EMAIL_CONFIRM_KEY] = email
             user.save_next_redirect_uri(self.request.get_full_path())
             return HttpResponseRedirect(reverse("accounts:confirm-email") + "?" + self.request.GET.urlencode())

--- a/inclusion_connect/templates/registration/email_verification_body.html
+++ b/inclusion_connect/templates/registration/email_verification_body.html
@@ -1,7 +1,13 @@
 {% extends "layout/base_email_body.html" %}
 {% block body %}
     <p>
-        Une demande de création de compte a été effectuée avec votre adresse
+        Une demande de
+        {% if registration %}
+            création
+        {% else %}
+            modification
+        {% endif %}
+        de compte a été effectuée avec votre adresse
         e-mail. Si vous êtes à l’origine de cette requête&nbsp;:
         <br>
     </p>

--- a/inclusion_connect/templates/registration/email_verification_body.txt
+++ b/inclusion_connect/templates/registration/email_verification_body.txt
@@ -1,6 +1,6 @@
 {% extends "layout/base_email_body.txt" %}
 {% block body %}
-Une demande de création de compte a été effectuée avec votre adresse e-mail. Si
+Une demande de {% if registration %}création{% else %}modification{% endif %} de compte a été effectuée avec votre adresse e-mail. Si
 vous êtes à l’origine de cette requête, veuillez cliquer sur le lien ci-dessous
 afin de vérifier votre adresse e-mail :
 


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Modifier-l-email-de-confirmation-de-compte-lorsqu-il-s-agit-d-une-modification-d-email-8fae9add86d84010a24207f4cbc2b2d8?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Pour ne pas indiquer "création de compte" dedans.
