### PR TITLE
Désactiver la restoration de la DB lors du déploiement sur Scalingo

### DIFF
--- a/.github/workflows/deploy-to-scalingo.yml
+++ b/.github/workflows/deploy-to-scalingo.yml
@@ -38,8 +38,9 @@ jobs:
     - name: Login to Scalingo
       run: scalingo login --ssh --ssh-identity ~/.ssh/id_ed25519
 
-    - name: Restore latest database backup
-      run: scalingo --region osc-secnum-fr1 --app $SCALINGO_APP_NAME run --size S python restore-backup.py
+    # TODO: Protect this step by reading the domain CNAME to make sure it does not point on Scalingo
+    # - name: Restore latest database backup
+    #   run: scalingo --region osc-secnum-fr1 --app $SCALINGO_APP_NAME run --size S python restore-backup.py
 
     - name: Deploy to Scalingo
       run: git push $SCALINGO_GIT_URL HEAD:main --force


### PR DESCRIPTION
### Pourquoi ?

Que je dorme mieux la nuit, sans m’inquiéter de supprimer la base de prod.