### PR TITLE
Ajout de Matomo

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -75,6 +75,9 @@ make runserver
 make test
 ```
 
+> [!NOTE]
+> Certains tests utilisent des snapshots via [syrupy](https://tophat.github.io/syrupy/). Lors de la modification de ces tests, il ne faudra pas oublier de relancer `pytest --snapshot-update` pour mettre les snapshots à jour.
+
 ## Normalement tout devrait être bon !
 
 Si tout va bien (croisons les doigts) vous aurez accès à l'admin : [http://localhost:8080/admin](http://localhost:8080/admin) et aux [autres urls](docs/inclusion_connect.md).

--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -122,7 +122,12 @@ class ActivateAccountView(BaseUserCreationView):
             return render(
                 request,
                 "oidc_authorize.html",
-                {"error": {"error": "invalid_request", "description": "Missing activation parameters"}},
+                {
+                    "error": {
+                        "error": "invalid_request",
+                        "description": "Missing activation parameters",
+                    }
+                },
                 status=400,
             )
         return super().dispatch(request, *args, **kwargs)
@@ -162,7 +167,8 @@ class PasswordResetView(auth_views.PasswordResetView):
             format_html(
                 "Si un compte existe avec cette adresse e-mail, "
                 "vous recevrez un e-mail contenant des instructions pour réinitialiser votre mot de passe."
-                '<br><a href="{}">J’ai besoin d’aide</a>',
+                '<br><a href="{}" class="matomo-event" data-matomo-category="aide" data-matomo-action="clic" '
+                "data-matomo-name=\"J'ai besoin d'aide (mdp reset)\">J’ai besoin d’aide</a>",
                 settings.FAQ_URL,
             ),
         )

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -143,7 +143,10 @@ if os.getenv("DATABASE_PERSISTENT_CONNECTIONS") == "True":
 
 AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
-    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator", "OPTIONS": {"min_length": 12}},
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {"min_length": 12},
+    },
     {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
     {"NAME": "inclusion_connect.utils.password_validation.CnilCompositionPasswordValidator"},
@@ -363,6 +366,13 @@ PASSWORD_HASHERS = [
     "inclusion_connect.keycloak_compat.hashers.KeycloakPasswordHasher",
 ]
 
+
+# MATOMO
+# ------
+
+MATOMO_BASE_URL = os.getenv("MATOMO_BASE_URL")
+MATOMO_SITE_ID = os.getenv("MATOMO_SITE_ID")
+
 # Content Security Policy
 # -----------------------
 
@@ -385,6 +395,10 @@ CSP_REPORT_URI = os.getenv("CSP_REPORT_URI", None)
 CSP_FRAME_ANCESTORS = ["'none'"]
 
 # CORS
+if MATOMO_BASE_URL:
+    CSP_IMG_SRC.append(MATOMO_BASE_URL)
+    CSP_SCRIPT_SRC.append(MATOMO_BASE_URL)
+    CSP_CONNECT_SRC.append(MATOMO_BASE_URL)
 # ----
 
 CORS_ALLOW_ALL_ORIGINS = os.getenv("CORS_ALLOW_ALL_ORIGINS") == "True"

--- a/inclusion_connect/static/js/index.js
+++ b/inclusion_connect/static/js/index.js
@@ -8,25 +8,39 @@ addEventListener("DOMContentLoaded", () => {
   // state of the button when clicking "Previous" in the browser, eventually
   // disabling moving forward afterwards!
 
-  document.querySelectorAll('form.js-prevent-multiple-submit').forEach((form) => {
-    let submitted = false;
-    function disableSubmit(event) {
-      if (submitted) {
-        event.preventDefault();
+  document
+    .querySelectorAll("form.js-prevent-multiple-submit")
+    .forEach((form) => {
+      let submitted = false;
+      function disableSubmit(event) {
+        if (submitted) {
+          event.preventDefault();
+        }
+        submitted = true;
       }
-      submitted = true;
+      form.addEventListener("submit", disableSubmit);
+    });
+
+  document.querySelectorAll(".matomo-event").forEach((mat) => {
+    if (mat.dataset.size !== 0) {
+      mat.addEventListener("click", () => {
+        var category = mat.dataset.matomoCategory;
+        var action = mat.dataset.matomoAction;
+        var name = mat.dataset.matomoName;
+
+        var _paq = (window._paq = window._paq || []);
+        _paq.push(["trackEvent", category, action, name]);
+      });
     }
-    form.addEventListener("submit", disableSubmit);
   });
 
-
-  const pwInput = document.querySelector('.password-with-instructions input');
+  const pwInput = document.querySelector(".password-with-instructions input");
   if (pwInput) {
     function indicatorStatus(elt, matchesCrit, label) {
-        elt.classList.toggle("ri-close-circle-line", !matchesCrit);
-        elt.classList.toggle("text-warning", !matchesCrit);
-        elt.classList.toggle("ri-checkbox-circle-line", matchesCrit);
-        elt.classList.toggle("text-success", matchesCrit);
+      elt.classList.toggle("ri-close-circle-line", !matchesCrit);
+      elt.classList.toggle("text-warning", !matchesCrit);
+      elt.classList.toggle("ri-checkbox-circle-line", matchesCrit);
+      elt.classList.toggle("text-success", matchesCrit);
     }
 
     const pwLengthIndicator = document.getElementById("pw-length");
@@ -53,9 +67,10 @@ addEventListener("DOMContentLoaded", () => {
       const specialCharOk = /(\W|_)/.test(pw);
       indicatorStatus(specialCharIndicator, specialCharOk);
 
-      const fieldOk = lengthOk && digitOk && lowerOk && upperOk && specialCharOk;
+      const fieldOk =
+        lengthOk && digitOk && lowerOk && upperOk && specialCharOk;
       pwInput.classList.toggle("is-invalid", !fieldOk);
       pwInput.classList.toggle("is-valid", fieldOk);
-    })
+    });
   }
 });

--- a/inclusion_connect/templates/accept_terms.html
+++ b/inclusion_connect/templates/accept_terms.html
@@ -23,7 +23,9 @@
 
     <form method="post" class="js-prevent-multiple-submit">
         {% csrf_token %}
-        <div>{% bootstrap_button "Accepter" button_type="submit" button_class="btn btn-block btn-primary" %}</div>
+        <div>
+            <button class="btn btn-block btn-primary" type="submit">Accepter</button>
+        </div>
     </form>
 
 

--- a/inclusion_connect/templates/activate_account.html
+++ b/inclusion_connect/templates/activate_account.html
@@ -26,12 +26,16 @@
                 </div>
             </div>
         </fieldset>
-        <div>{% bootstrap_button "S'inscrire" button_type="submit" button_class="btn btn-block btn-primary" %}</div>
+        <div>
+            <button class="btn btn-block btn-primary matomo-event" type="submit" data-matomo-category="inscription" data-matomo-action="clic" data-matomo-name="S'inscrire">
+                S'inscrire
+            </button>
+        </div>
     </form>
 
     <hr class="my-3 my-lg-4">
     <div class="text-center">
-        Vous avez déjà un compte ?<a href="{% url 'login' %}" class="btn btn-link">Connectez-vous</a>
+        Vous avez déjà un compte ?<a href="{% url 'login' %}" class="btn btn-link matomo-event" data-matomo-category="inscription" data-matomo-action="clic" data-matomo-name="Connectez-vous">Connectez-vous</a>
     </div>
 
 {% endblock %}

--- a/inclusion_connect/templates/change_password.html
+++ b/inclusion_connect/templates/change_password.html
@@ -18,7 +18,9 @@
             </div>
         </fieldset>
         <div>
-            {% bootstrap_button "Modifier mon mot de passe" button_type="submit" button_class="btn btn-block btn-primary" %}
+            <button class="btn btn-block btn-primary matomo-event" type="submit" data-matomo-category="compte" data-matomo-action="clic" data-matomo-name="Modifier mon mot de passe">
+                Modifier mon mot de passe
+            </button>
         </div>
     </form>
 {% endblock %}

--- a/inclusion_connect/templates/edit_user_info.html
+++ b/inclusion_connect/templates/edit_user_info.html
@@ -33,7 +33,9 @@
                 </div>
             </fieldset>
             <div>
-                {% bootstrap_button "Enregistrer les modifications" button_type="submit" button_class="btn btn-block btn-primary" %}
+                <button class="btn btn-block btn-primary matomo-event" type="submit" data-matomo-category="compte" data-matomo-action="clic" data-matomo-name="Enregistrer les modifications">
+                    Enregistrer les modifications
+                </button>
             </div>
         </form>
     {% endif %}

--- a/inclusion_connect/templates/email_confirmation.html
+++ b/inclusion_connect/templates/email_confirmation.html
@@ -18,12 +18,14 @@
 
     <form method="post" class="js-prevent-multiple-submit">
         {% csrf_token %}
-        {% bootstrap_button "Renvoyer l’e-mail de vérification" button_type="submit" button_class="btn btn-block btn-primary" %}
+        <button class="btn btn-block btn-primary matomo-event" type="submit" data-matomo-category="email" data-matomo-action="clic" data-matomo-name="Renvoyer l’e-mail de vérification">
+            Renvoyer l’e-mail de vérification
+        </button>
     </form>
 
     <br>
 
     <div class="text-center">
-        <a href="{{ FAQ_URL }}" class="btn btn-link">J'ai besoin d'aide</a>
+        <a href="{{ FAQ_URL }}" class="btn btn-link matomo-event" data-matomo-category="aide" data-matomo-action="clic" data-matomo-name="J'ai besoin d'aide (email)">J'ai besoin d'aide</a>
     </div>
 {% endblock %}

--- a/inclusion_connect/templates/includes/pe_connect.html
+++ b/inclusion_connect/templates/includes/pe_connect.html
@@ -7,7 +7,7 @@
     </div>
 {% endif %}
 
-<a class="btn btn-block pe-connect" href="{% url 'oidc_federation:peama:init' %}">
+<a class="btn btn-block pe-connect matomo-event" href="{% url 'oidc_federation:peama:init' %}" data-matomo-category="peama" data-matomo-action="clic" data-matomo-name="Connexion agents Pôle emploi">
     <img class="me-2" height="30" src="{% static "img/icon-pe-connect.svg" %}" alt="">
     <span>Connexion agents Pôle emploi
         {% if PEAMA_STAGING %}(Test){% endif %}

--- a/inclusion_connect/templates/layout/_footer.html
+++ b/inclusion_connect/templates/layout/_footer.html
@@ -41,7 +41,8 @@
                 <div class="s-footer-legal__col col-12">
                     <ul>
                         <li>
-                            <a href="{{ FAQ_URL }}" target="_blank">Aide</a>
+                            <a href="{{ FAQ_URL }}" class="matomo-event" data-matomo-category="aide" data-matomo-action="clic" data-matomo-name="Aide (footer)" target="_blank">Aide</a>
+
                         </li>
                         <li>
                             <a href="{% static PRIVACY_POLICY_PATH %}" target="_blank">Politique de confidentialité</a>

--- a/inclusion_connect/templates/layout/base.html
+++ b/inclusion_connect/templates/layout/base.html
@@ -34,7 +34,24 @@
 
         {% include "layout/_footer.html" %}
 
-        {# Add matomo #}
+
+        {% if MATOMO_BASE_URL %}
+            <!-- Matomo -->
+            <script id="matomo-custom-init" nonce="{{ CSP_NONCE }}">
+              var _paq = window._paq = window._paq || [];
+              _paq.push(['trackPageView']);
+              _paq.push(['enableLinkTracking']);
+              (function() {
+                var u="{{MATOMO_BASE_URL}}";
+                _paq.push(['setTrackerUrl', u+'matomo.php']);
+                _paq.push(['setSiteId', {{ MATOMO_SITE_ID }}]);
+                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+              })();
+            </script>
+            <!-- End Matomo Code -->
+        {% endif %}
+
         {# Add tarteaucitron #}
         {# Add Je donne mon avis or NPS #}
 

--- a/inclusion_connect/templates/login.html
+++ b/inclusion_connect/templates/login.html
@@ -31,7 +31,11 @@
                 </div>
             </div>
         </fieldset>
-        <div>{% bootstrap_button "Connexion" button_type="submit" button_class="btn btn-block btn-primary" %}</div>
+        <div>
+            <button class="btn btn-block btn-primary matomo-event" type="submit" data-matomo-category="authentification" data-matomo-action="clic" data-matomo-name="Connexion">
+                Connexion
+            </button>
+        </div>
     </form>
 
     {% if PEAMA_ENABLED %}
@@ -42,7 +46,7 @@
     <hr class="my-3 my-lg-4">
     <div class="text-center">
         <h2 class="h5">Vous n’avez pas de compte Inclusion Connect ?</h2>
-        <a href="{% url 'accounts:register' %}" class="btn btn-link">Créer mon compte</a>
+        <a href="{% url 'accounts:register' %}" class="btn btn-link matomo-event" data-matomo-category="authentification" data-matomo-action="clic" data-matomo-name="Créer mon compte">Créer mon compte</a>
     </div>
 
 {% endblock %}

--- a/inclusion_connect/templates/password_reset.html
+++ b/inclusion_connect/templates/password_reset.html
@@ -16,12 +16,17 @@
                 <div class="col-12">{% bootstrap_form form %}</div>
             </div>
         </fieldset>
-        <div>{% bootstrap_button "Soumettre" button_type="submit" button_class="btn btn-block btn-primary" %}</div>
+        <div>
+
+            <button class="btn btn-block btn-primary matomo-event" type="submit" data-matomo-category="reinitialisation-mdp" data-matomo-action="clic" data-matomo-name="Soumettre email confirmation">
+                Soumettre
+            </button>
+        </div>
     </form>
 
     <hr class="my-3 my-lg-4">
     <div class="text-center">
-        <a href="{% url 'login' %}" class="btn btn-link">Retour à la connexion</a>
+        <a href="{% url 'login' %}" class="btn btn-link matomo-event" data-matomo-category="reinitialisation-mdp" data-matomo-action="clic" data-matomo-name="Retour à la connexion">Retour à la connexion</a>
     </div>
 
 {% endblock %}

--- a/inclusion_connect/templates/password_reset_confirm.html
+++ b/inclusion_connect/templates/password_reset_confirm.html
@@ -18,7 +18,11 @@
                     </div>
                 </div>
             </fieldset>
-            <div>{% bootstrap_button "Soumettre" button_type="submit" button_class="btn btn-block btn-primary" %}</div>
+            <div>
+                <button class="btn btn-block btn-primary matomo-event" type="submit" data-matomo-category="reinitialisation-mdp" data-matomo-action="clic" data-matomo-name="Soumettre changement de mdp">
+                    Soumettre
+                </button>
+            </div>
         </form>
     {% else %}
         <div>

--- a/inclusion_connect/templates/register.html
+++ b/inclusion_connect/templates/register.html
@@ -40,12 +40,16 @@
                 </div>
             </div>
         </fieldset>
-        <div>{% bootstrap_button "S'inscrire" button_type="submit" button_class="btn btn-block btn-primary" %}</div>
+        <div>
+            <button class="btn btn-block btn-primary matomo-event" type="submit" data-matomo-category="inscription" data-matomo-action="clic" data-matomo-name="S'inscrire">
+                S'inscrire
+            </button>
+        </div>
     </form>
 
     <hr class="my-3 my-lg-4">
     <div class="text-center">
-        Vous avez déjà un compte ?<a href="{% url 'login' %}" class="btn btn-link">Connectez-vous</a>
+        Vous avez déjà un compte ?<a href="{% url 'login' %}" class="btn btn-link matomo-event" data-matomo-category="inscription" data-matomo-action="clic" data-matomo-name="Connectez-vous">Connectez-vous</a>
     </div>
 
 {% endblock %}

--- a/inclusion_connect/utils/context_processors.py
+++ b/inclusion_connect/utils/context_processors.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 
 def expose_settings(*args):
-    return {
+    settings_to_expose = {
         key: getattr(settings, key)
         for key in [
             "FAQ_URL",
@@ -13,3 +13,9 @@ def expose_settings(*args):
             "PEAMA_ENABLED",
         ]
     }
+
+    global_constants_settings_to_expose = {
+        "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
+        "MATOMO_BASE_URL": settings.MATOMO_BASE_URL,
+    }
+    return {**settings_to_expose, **global_constants_settings_to_expose}

--- a/tests/__snapshots__/test_builtin_views.ambr
+++ b/tests/__snapshots__/test_builtin_views.ambr
@@ -1,21 +1,17 @@
 # serializer version: 1
 # name: test_csrf_view
   '''
-  
-  
-  
-  <!DOCTYPE HTML>
-  <html lang="fr">
-      <head>
-          <meta charset="utf-8">
+  <!DOCTYPE html>
+  <html lang="fr"><head>
+          <meta charset="utf-8"/>
           <title>Inclusion Connect</title>
-          <meta name="robots" content="noindex, nofollow">
-          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <meta content="noindex, nofollow" name="robots"/>
+          <meta content="width=device-width, initial-scale=1" name="viewport"/>
   
-          <link rel="icon" href="/static/img/illustration-bg-ic.svg" type="image/svg+xml">
-          <link rel="icon" href="/static/img/favicon.ico" type="image/ico">
-          <link rel="stylesheet" href="/static/vendor/theme-inclusion/stylesheets/app.css" type="text/css">
-          <link rel="stylesheet" href="/static/css/inclusion_connect.css" type="text/css">
+          <link href="/static/img/illustration-bg-ic.svg" rel="icon" type="image/svg+xml"/>
+          <link href="/static/img/favicon.ico" rel="icon" type="image/ico"/>
+          <link href="/static/vendor/theme-inclusion/stylesheets/app.css" rel="stylesheet" type="text/css"/>
+          <link href="/static/css/inclusion_connect.css" rel="stylesheet" type="text/css"/>
   
           
       </head>
@@ -24,15 +20,15 @@
   
   
   
-  <header role="banner" id="header">
+  <header id="header" role="banner">
       <section class="s-header">
           <div class="s-header__container container">
               <div class="s-header__row row">
                   <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center ps-xl-0 pe-0">
-                      <img src="/static/vendor/theme-inclusion/images/logo-ministere-emploi.svg" alt="Ministère du travail, du plein emploi et de l'insertion" />
+                      <img alt="Ministère du travail, du plein emploi et de l'insertion" src="/static/vendor/theme-inclusion/images/logo-ministere-emploi.svg"/>
                   </div>
                   <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">
-                      <img src="/static/vendor/theme-inclusion/images/logo-inclusion-connect.svg" alt="Inclusion Connect" height="90" />
+                      <img alt="Inclusion Connect" height="90" src="/static/vendor/theme-inclusion/images/logo-inclusion-connect.svg"/>
                   </div>
                   <div class="s-header__col s-header__col--burger col d-flex align-items-center justify-content-end d-xl-none"></div>
               </div>
@@ -41,7 +37,7 @@
   </header>
   
   
-          <main id="main" role="main" class="s-main">
+          <main class="s-main" id="main" role="main">
   
               <section class="s-section pt-lg-3">
                   <div class="container">
@@ -75,7 +71,7 @@
   
                           
       <div class="d-none d-lg-flex col-lg-6 p-lg-6 justify-content-center align-items-center bg-light">
-          <img class="img-fluid" src="/static/img/illustration-ic.svg" alt="" loading="lazy">
+          <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-ic.svg"/>
       </div>
   
                       </div>
@@ -87,12 +83,12 @@
           
   
   
-  <footer role="contentinfo" id="footer">
+  <footer id="footer" role="contentinfo">
       <section class="s-footer-gip">
           <div class="s-footer-gip__container container">
               <div class="s-footer-gip__row row">
                   <div class="s-footer-gip__col s-footer-gip__col--logo col-12 col-md-auto col-lg-auto">
-                      <img src="/static/vendor/theme-inclusion/images/logo-republique-francaise.svg" alt="Rébublique Française" class="img-fluid" width="130">
+                      <img alt="Rébublique Française" class="img-fluid" src="/static/vendor/theme-inclusion/images/logo-republique-francaise.svg" width="130"/>
                   </div>
                   <div class="s-footer-gip__col col-12 col-md col-lg">
                       <p class="mb-1">
@@ -100,20 +96,20 @@
                       </p>
                       <p class="m-0">
                           Vous constatez un problème de sécurité sur le service ?
-                          <br class="d-none d-md-inline">
+                          <br class="d-none d-md-inline"/>
                           Signalez-le nous à cette adresse <a href="mailto: support@connect.inclusion.beta.gouv.fr">support@connect.inclusion.beta.gouv.fr</a>.
                       </p>
                   </div>
                   <div class="s-footer-gip__col s-footer-gip__col--links col-12 col-lg-auto">
                       <ul>
                           <li>
-                              <a href="https://beta.gouv.fr/" target="_blank" aria-label="Incubateur de services publics numériques — beta.gouv.fr (lien externe)">beta.gouv.fr</a>
+                              <a aria-label="Incubateur de services publics numériques — beta.gouv.fr (lien externe)" href="https://beta.gouv.fr/" target="_blank">beta.gouv.fr</a>
                           </li>
                           <li>
-                              <a href="https://www.data.gouv.fr/fr/" target="_blank" aria-label="Data.gouv.fr (lien externe)">data.gouv.fr</a>
+                              <a aria-label="Data.gouv.fr (lien externe)" href="https://www.data.gouv.fr/fr/" target="_blank">data.gouv.fr</a>
                           </li>
                           <li>
-                              <a href="https://api.gouv.fr/" target="_blank" aria-label="Simplifiez le partage et la circulation des données administratives grace à api.gouv.fr (lien externe)">api.gouv.fr</a>
+                              <a aria-label="Simplifiez le partage et la circulation des données administratives grace à api.gouv.fr (lien externe)" href="https://api.gouv.fr/" target="_blank">api.gouv.fr</a>
                           </li>
                       </ul>
                   </div>
@@ -127,7 +123,8 @@
                   <div class="s-footer-legal__col col-12">
                       <ul>
                           <li>
-                              <a href="https://plateforme-inclusion.notion.site/Questions-fr-quentes-74a872c96637484f8a7dbfa6b44eeb08" target="_blank">Aide</a>
+                              <a class="matomo-event" data-matomo-action="clic" data-matomo-category="aide" data-matomo-name="Aide (footer)" href="https://plateforme-inclusion.notion.site/Questions-fr-quentes-74a872c96637484f8a7dbfa6b44eeb08" target="_blank">Aide</a>
+  
                           </li>
                           <li>
                               <a href="/static/terms/Politique_de_confidentialite_v5.pdf" target="_blank">Politique de confidentialité</a>
@@ -146,7 +143,24 @@
   </footer>
   
   
+  
           
+              <!-- Matomo -->
+              <script id="matomo-custom-init" nonce="NORMALIZED_CSP_NONCE">
+                var _paq = window._paq = window._paq || [];
+                _paq.push(['trackPageView']);
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                  var u="https://matomo.example.com";
+                  _paq.push(['setTrackerUrl', u+'matomo.php']);
+                  _paq.push(['setSiteId', 1]);
+                  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                  g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+              </script>
+              <!-- End Matomo Code -->
+          
+  
           
           
   
@@ -157,8 +171,8 @@
           
               <script src="/static/js/index.js"></script>
           
-      </body>
-  </html>
+      
   
+  </body></html>
   '''
 # ---

--- a/tests/__snapshots__/test_homepage.ambr
+++ b/tests/__snapshots__/test_homepage.ambr
@@ -1,21 +1,17 @@
 # serializer version: 1
 # name: test_homepage
   '''
-  
-  
-  
-  <!DOCTYPE HTML>
-  <html lang="fr">
-      <head>
-          <meta charset="utf-8">
+  <!DOCTYPE html>
+  <html lang="fr"><head>
+          <meta charset="utf-8"/>
           <title>Inclusion Connect</title>
-          <meta name="robots" content="noindex, nofollow">
-          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <meta content="noindex, nofollow" name="robots"/>
+          <meta content="width=device-width, initial-scale=1" name="viewport"/>
   
-          <link rel="icon" href="/static/img/illustration-bg-ic.svg" type="image/svg+xml">
-          <link rel="icon" href="/static/img/favicon.ico" type="image/ico">
-          <link rel="stylesheet" href="/static/vendor/theme-inclusion/stylesheets/app.css" type="text/css">
-          <link rel="stylesheet" href="/static/css/inclusion_connect.css" type="text/css">
+          <link href="/static/img/illustration-bg-ic.svg" rel="icon" type="image/svg+xml"/>
+          <link href="/static/img/favicon.ico" rel="icon" type="image/ico"/>
+          <link href="/static/vendor/theme-inclusion/stylesheets/app.css" rel="stylesheet" type="text/css"/>
+          <link href="/static/css/inclusion_connect.css" rel="stylesheet" type="text/css"/>
   
           
       </head>
@@ -24,15 +20,15 @@
   
   
   
-  <header role="banner" id="header">
+  <header id="header" role="banner">
       <section class="s-header">
           <div class="s-header__container container">
               <div class="s-header__row row">
                   <div class="s-header__col s-header__col--logo-ministere col col-md-auto d-flex align-items-center ps-xl-0 pe-0">
-                      <img src="/static/vendor/theme-inclusion/images/logo-ministere-emploi.svg" alt="Ministère du travail, du plein emploi et de l'insertion" />
+                      <img alt="Ministère du travail, du plein emploi et de l'insertion" src="/static/vendor/theme-inclusion/images/logo-ministere-emploi.svg"/>
                   </div>
                   <div class="s-header__col s-header__col--logo-service col-auto d-flex align-items-center px-0">
-                      <img src="/static/vendor/theme-inclusion/images/logo-inclusion-connect.svg" alt="Inclusion Connect" height="90" />
+                      <img alt="Inclusion Connect" height="90" src="/static/vendor/theme-inclusion/images/logo-inclusion-connect.svg"/>
                   </div>
                   <div class="s-header__col s-header__col--burger col d-flex align-items-center justify-content-end d-xl-none"></div>
               </div>
@@ -41,7 +37,7 @@
   </header>
   
   
-          <main id="main" role="main" class="s-main">
+          <main class="s-main" id="main" role="main">
   
               <section class="s-section pt-lg-3">
                   <div class="container">
@@ -65,7 +61,7 @@
           Inclusion Connect est une solution de connexion unique à plusieurs services publics pour les professionnels de l'inclusion.
       </p>
   
-      <a href="https://inclusion.beta.gouv.fr/nos-services/inclusion-connect/" target="_blank" class="has-external-link" aria-label="En savoir plus sur Inclusion Connect(lien externe)">En savoir plus</a>
+      <a aria-label="En savoir plus sur Inclusion Connect(lien externe)" class="has-external-link" href="https://inclusion.beta.gouv.fr/nos-services/inclusion-connect/" target="_blank">En savoir plus</a>
   
   
           </div>
@@ -73,7 +69,7 @@
   
                           
       <div class="d-none d-lg-flex col-lg-6 p-lg-6 justify-content-center align-items-center bg-light">
-          <img class="img-fluid" src="/static/img/illustration-ic.svg" alt="" loading="lazy">
+          <img alt="" class="img-fluid" loading="lazy" src="/static/img/illustration-ic.svg"/>
       </div>
   
                       </div>
@@ -85,12 +81,12 @@
           
   
   
-  <footer role="contentinfo" id="footer">
+  <footer id="footer" role="contentinfo">
       <section class="s-footer-gip">
           <div class="s-footer-gip__container container">
               <div class="s-footer-gip__row row">
                   <div class="s-footer-gip__col s-footer-gip__col--logo col-12 col-md-auto col-lg-auto">
-                      <img src="/static/vendor/theme-inclusion/images/logo-republique-francaise.svg" alt="Rébublique Française" class="img-fluid" width="130">
+                      <img alt="Rébublique Française" class="img-fluid" src="/static/vendor/theme-inclusion/images/logo-republique-francaise.svg" width="130"/>
                   </div>
                   <div class="s-footer-gip__col col-12 col-md col-lg">
                       <p class="mb-1">
@@ -98,20 +94,20 @@
                       </p>
                       <p class="m-0">
                           Vous constatez un problème de sécurité sur le service ?
-                          <br class="d-none d-md-inline">
+                          <br class="d-none d-md-inline"/>
                           Signalez-le nous à cette adresse <a href="mailto: support@connect.inclusion.beta.gouv.fr">support@connect.inclusion.beta.gouv.fr</a>.
                       </p>
                   </div>
                   <div class="s-footer-gip__col s-footer-gip__col--links col-12 col-lg-auto">
                       <ul>
                           <li>
-                              <a href="https://beta.gouv.fr/" target="_blank" aria-label="Incubateur de services publics numériques — beta.gouv.fr (lien externe)">beta.gouv.fr</a>
+                              <a aria-label="Incubateur de services publics numériques — beta.gouv.fr (lien externe)" href="https://beta.gouv.fr/" target="_blank">beta.gouv.fr</a>
                           </li>
                           <li>
-                              <a href="https://www.data.gouv.fr/fr/" target="_blank" aria-label="Data.gouv.fr (lien externe)">data.gouv.fr</a>
+                              <a aria-label="Data.gouv.fr (lien externe)" href="https://www.data.gouv.fr/fr/" target="_blank">data.gouv.fr</a>
                           </li>
                           <li>
-                              <a href="https://api.gouv.fr/" target="_blank" aria-label="Simplifiez le partage et la circulation des données administratives grace à api.gouv.fr (lien externe)">api.gouv.fr</a>
+                              <a aria-label="Simplifiez le partage et la circulation des données administratives grace à api.gouv.fr (lien externe)" href="https://api.gouv.fr/" target="_blank">api.gouv.fr</a>
                           </li>
                       </ul>
                   </div>
@@ -125,7 +121,8 @@
                   <div class="s-footer-legal__col col-12">
                       <ul>
                           <li>
-                              <a href="https://plateforme-inclusion.notion.site/Questions-fr-quentes-74a872c96637484f8a7dbfa6b44eeb08" target="_blank">Aide</a>
+                              <a class="matomo-event" data-matomo-action="clic" data-matomo-category="aide" data-matomo-name="Aide (footer)" href="https://plateforme-inclusion.notion.site/Questions-fr-quentes-74a872c96637484f8a7dbfa6b44eeb08" target="_blank">Aide</a>
+  
                           </li>
                           <li>
                               <a href="/static/terms/Politique_de_confidentialite_v5.pdf" target="_blank">Politique de confidentialité</a>
@@ -144,7 +141,24 @@
   </footer>
   
   
+  
           
+              <!-- Matomo -->
+              <script id="matomo-custom-init" nonce="NORMALIZED_CSP_NONCE">
+                var _paq = window._paq = window._paq || [];
+                _paq.push(['trackPageView']);
+                _paq.push(['enableLinkTracking']);
+                (function() {
+                  var u="https://matomo.example.com";
+                  _paq.push(['setTrackerUrl', u+'matomo.php']);
+                  _paq.push(['setSiteId', 1]);
+                  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                  g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+                })();
+              </script>
+              <!-- End Matomo Code -->
+          
+  
           
           
   
@@ -155,8 +169,8 @@
           
               <script src="/static/js/index.js"></script>
           
-      </body>
-  </html>
+      
   
+  </body></html>
   '''
 # ---

--- a/tests/accounts/__snapshots__/tests.ambr
+++ b/tests/accounts/__snapshots__/tests.ambr
@@ -34,13 +34,15 @@
   
       <form class="js-prevent-multiple-submit" method="post">
           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-          <button class="btn btn-block btn-primary" type="submit">Renvoyer l’e-mail de vérification</button>
+          <button class="btn btn-block btn-primary matomo-event" data-matomo-action="clic" data-matomo-category="email" data-matomo-name="Renvoyer l’e-mail de vérification" type="submit">
+              Renvoyer l’e-mail de vérification
+          </button>
       </form>
   
       <br/>
   
       <div class="text-center">
-          <a class="btn btn-link" href="https://plateforme-inclusion.notion.site/Questions-fr-quentes-74a872c96637484f8a7dbfa6b44eeb08">J'ai besoin d'aide</a>
+          <a class="btn btn-link matomo-event" data-matomo-action="clic" data-matomo-category="aide" data-matomo-name="J'ai besoin d'aide (email)" href="https://plateforme-inclusion.notion.site/Questions-fr-quentes-74a872c96637484f8a7dbfa6b44eeb08">J'ai besoin d'aide</a>
       </div>
   
           </div>

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -65,7 +65,10 @@ class TestLoginView:
     def test_no_next_url(self, caplog, client):
         user = UserFactory()
 
-        response = client.post(reverse("accounts:login"), data={"email": user.email, "password": DEFAULT_PASSWORD})
+        response = client.post(
+            reverse("accounts:login"),
+            data={"email": user.email, "password": DEFAULT_PASSWORD},
+        )
         assertRedirects(response, reverse("accounts:edit_user_info"))
         assert get_user(client).is_authenticated is True
         assertRecords(
@@ -318,7 +321,10 @@ class TestLoginView:
                 )
             ],
         )
-        assertContains(response, "Votre compte est relié à Pôle emploi. Merci de vous connecter avec ce service.")
+        assertContains(
+            response,
+            "Votre compte est relié à Pôle emploi. Merci de vous connecter avec ce service.",
+        )
 
     def test_pole_emploi_user_cannot_use_login_password(self, client, caplog):
         redirect_url = reverse("oauth2_provider:rp-initiated-logout")
@@ -454,7 +460,11 @@ class TestRegisterView:
                 (
                     "inclusion_connect.auth",
                     logging.INFO,
-                    {"email": "user@mailinator.com", "user": user_from_db.pk, "event": "register"},
+                    {
+                        "email": "user@mailinator.com",
+                        "user": user_from_db.pk,
+                        "event": "register",
+                    },
                 )
             ],
         )
@@ -637,7 +647,14 @@ class TestRegisterView:
                     {
                         "email": user.email,
                         "event": "register_error",
-                        "errors": {"terms_accepted": [{"message": "Ce champ est obligatoire.", "code": "required"}]},
+                        "errors": {
+                            "terms_accepted": [
+                                {
+                                    "message": "Ce champ est obligatoire.",
+                                    "code": "required",
+                                }
+                            ]
+                        },
                     },
                 )
             ],
@@ -721,7 +738,10 @@ class TestActivateAccountView:
         # If missing params in oidc session
         response = client.get(url)
         assert response.status_code == 400
-        assertRecords(caplog, [("django.request", logging.WARNING, "Bad Request: /accounts/activate/")])
+        assertRecords(
+            caplog,
+            [("django.request", logging.WARNING, "Bad Request: /accounts/activate/")],
+        )
 
         client_session = client.session
         client_session[OIDC_SESSION_KEY] = {
@@ -779,7 +799,10 @@ class TestActivateAccountView:
         # If missing params in oidc session
         response = client.get(url)
         assert response.status_code == 400
-        assertRecords(caplog, [("django.request", logging.WARNING, "Bad Request: /accounts/activate/")])
+        assertRecords(
+            caplog,
+            [("django.request", logging.WARNING, "Bad Request: /accounts/activate/")],
+        )
 
         client_session = client.session
         client_session[OIDC_SESSION_KEY] = {
@@ -948,7 +971,14 @@ class TestActivateAccountView:
                         "application": application.client_id,
                         "email": user.email,
                         "event": "activate_error",
-                        "errors": {"terms_accepted": [{"message": "Ce champ est obligatoire.", "code": "required"}]},
+                        "errors": {
+                            "terms_accepted": [
+                                {
+                                    "message": "Ce champ est obligatoire.",
+                                    "code": "required",
+                                }
+                            ]
+                        },
                     },
                 )
             ],
@@ -980,7 +1010,9 @@ class TestPasswordResetView:
                         messages.SUCCESS,
                         "Si un compte existe avec cette adresse e-mail, "
                         "vous recevrez un e-mail contenant des instructions pour réinitialiser votre mot de passe."
-                        f'<br><a href="{settings.FAQ_URL}">J’ai besoin d’aide</a>',
+                        f'<br><a href="{settings.FAQ_URL}" class="matomo-event" data-matomo-category="aide" '
+                        'data-matomo-action="clic" data-matomo-name="J\'ai besoin d\'aide (mdp reset)">'
+                        "J’ai besoin d’aide</a>",
                     ),
                 ],
             )
@@ -1005,14 +1037,20 @@ class TestPasswordResetView:
         # More than a day after link generation
         with freeze_time("2023-06-09 09:10:04"):
             response = client.get(password_reset_url)
-            assertContains(response, "Veuillez renouveler votre demande de mise à jour de mot de passe.")
+            assertContains(
+                response,
+                "Veuillez renouveler votre demande de mise à jour de mot de passe.",
+            )
 
         # Exaclty a day after link generation
         with freeze_time("2023-06-09 09:10:03"):
             # Change password
             password = "V€r¥--$3©®€7"
             response = client.get(password_reset_url)  # retrieve the modified url
-            response = client.post(response.url, data={"new_password1": password, "new_password2": password})
+            response = client.post(
+                response.url,
+                data={"new_password1": password, "new_password2": password},
+            )
 
             # User is now logged in and redirected to next_url
             assertRedirects(response, redirect_url, fetch_redirect_response=False)
@@ -1057,7 +1095,9 @@ class TestPasswordResetView:
                     messages.SUCCESS,
                     "Si un compte existe avec cette adresse e-mail, "
                     "vous recevrez un e-mail contenant des instructions pour réinitialiser votre mot de passe."
-                    f'<br><a href="{settings.FAQ_URL}">J’ai besoin d’aide</a>',
+                    f'<br><a href="{settings.FAQ_URL}" class="matomo-event" data-matomo-category="aide" '
+                    'data-matomo-action="clic" data-matomo-name="J\'ai besoin d\'aide (mdp reset)">'
+                    "J’ai besoin d’aide</a>",
                 ),
             ],
         )
@@ -1096,7 +1136,9 @@ class TestPasswordResetView:
                     messages.SUCCESS,
                     "Si un compte existe avec cette adresse e-mail, "
                     "vous recevrez un e-mail contenant des instructions pour réinitialiser votre mot de passe."
-                    f'<br><a href="{settings.FAQ_URL}">J’ai besoin d’aide</a>',
+                    f'<br><a href="{settings.FAQ_URL}" class="matomo-event" data-matomo-category="aide" '
+                    'data-matomo-action="clic" data-matomo-name="J\'ai besoin d\'aide (mdp reset)">'
+                    "J’ai besoin d’aide</a>",
                 ),
             ],
         )
@@ -1149,7 +1191,9 @@ class TestPasswordResetView:
                     messages.SUCCESS,
                     "Si un compte existe avec cette adresse e-mail, "
                     "vous recevrez un e-mail contenant des instructions pour réinitialiser votre mot de passe."
-                    f'<br><a href="{settings.FAQ_URL}">J’ai besoin d’aide</a>',
+                    f'<br><a href="{settings.FAQ_URL}" class="matomo-event" data-matomo-category="aide" '
+                    'data-matomo-action="clic" data-matomo-name="J\'ai besoin d\'aide (mdp reset)">'
+                    "J’ai besoin d’aide</a>",
                 ),
             ],
         )
@@ -1207,7 +1251,10 @@ class TestPasswordResetConfirmView:
         response = client.get(reverse("accounts:password_reset_confirm", args=(uid, token)))
         print(response.url)
         assertRedirects(response, response.url, fetch_redirect_response=False)
-        response = client.post(response.url, data={"new_password1": "password", "new_password2": "password-typo"})
+        response = client.post(
+            response.url,
+            data={"new_password1": "password", "new_password2": "password-typo"},
+        )
         assert response.status_code == 200
         assertRecords(
             caplog,
@@ -1306,7 +1353,11 @@ class TestEditUserInfoView:
         # Edit user info
         response = client.post(
             edit_user_info_url,
-            data={"last_name": "Doe", "first_name": "John", "email": "jo-with-typo@email.com"},
+            data={
+                "last_name": "Doe",
+                "first_name": "John",
+                "email": "jo-with-typo@email.com",
+            },
         )
         assertRedirects(response, add_url_params(reverse("accounts:confirm-email"), params))
         user.refresh_from_db()
@@ -1466,7 +1517,14 @@ class TestEditUserInfoView:
                         "event": "edit_user_info_error",
                         "user": user.pk,
                         "application": application.client_id,
-                        "errors": {"email": [{"message": "Ce champ est obligatoire.", "code": "required"}]},
+                        "errors": {
+                            "email": [
+                                {
+                                    "message": "Ce champ est obligatoire.",
+                                    "code": "required",
+                                }
+                            ]
+                        },
                     },
                 )
             ],
@@ -1476,7 +1534,10 @@ class TestEditUserInfoView:
         BUTTON_HTML_STR = 'type="submit"'
         application = ApplicationFactory()
         user = UserFactory(first_name="Jean", last_name="Dupond", email="jean.dupond@email.com")
-        client.force_login(user, backend="inclusion_connect.oidc_federation.peama.OIDCAuthenticationBackend")
+        client.force_login(
+            user,
+            backend="inclusion_connect.oidc_federation.peama.OIDCAuthenticationBackend",
+        )
         params = {"referrer_uri": "rp_url", "referrer": application.client_id}
         edit_user_info_url = add_url_params(reverse("accounts:edit_user_info"), params)
         response = client.get(edit_user_info_url)
@@ -1495,7 +1556,10 @@ class TestEditUserInfoView:
         assert user.first_name == "Jean"
         assert user.last_name == "Dupond"
         assert user.email == "jean.dupond@email.com"
-        assertRecords(caplog, [("django.request", logging.WARNING, "Forbidden: /accounts/my-account/")])
+        assertRecords(
+            caplog,
+            [("django.request", logging.WARNING, "Forbidden: /accounts/my-account/")],
+        )
 
 
 class TestPasswordChangeView:
@@ -1515,7 +1579,10 @@ class TestPasswordChangeView:
 
         # with referrer_uri
         response = client.get(change_password_url)
-        assertContains(response, "<h1>\n                Changer mon mot de passe\n            </h1>")
+        assertContains(
+            response,
+            "<h1>\n                Changer mon mot de passe\n            </h1>",
+        )
         # Left menu contains both pages
         assertContains(response, escape(edit_user_info_url))
         assertContains(response, escape(change_password_url))
@@ -1526,7 +1593,11 @@ class TestPasswordChangeView:
         # Go change password
         response = client.post(
             change_password_url,
-            data={"old_password": DEFAULT_PASSWORD, "new_password1": "V€r¥--$3©®€7", "new_password2": "V€r¥--$3©®€7"},
+            data={
+                "old_password": DEFAULT_PASSWORD,
+                "new_password1": "V€r¥--$3©®€7",
+                "new_password2": "V€r¥--$3©®€7",
+            },
         )
         assertRedirects(response, change_password_url)
         assert get_user(client).is_authenticated is True
@@ -1536,7 +1607,11 @@ class TestPasswordChangeView:
                 (
                     "inclusion_connect.auth",
                     logging.INFO,
-                    {"event": "change_password", "user": user.pk, "application": application.client_id},
+                    {
+                        "event": "change_password",
+                        "user": user.pk,
+                        "application": application.client_id,
+                    },
                 )
             ],
         )
@@ -1545,7 +1620,9 @@ class TestPasswordChangeView:
         assert get_user(client).is_authenticated is False
 
         response = client.post(
-            reverse("accounts:login"), data={"email": user.email, "password": "V€r¥--$3©®€7"}, follow=True
+            reverse("accounts:login"),
+            data={"email": user.email, "password": "V€r¥--$3©®€7"},
+            follow=True,
         )
         assert get_user(client).is_authenticated is True
         assertRecords(
@@ -1564,7 +1641,11 @@ class TestPasswordChangeView:
         client.force_login(user)
         response = client.post(
             reverse("accounts:change_password"),
-            data={"old_password": DEFAULT_PASSWORD, "new_password1": "password", "new_password2": "password"},
+            data={
+                "old_password": DEFAULT_PASSWORD,
+                "new_password1": "password",
+                "new_password2": "password",
+            },
         )
         assert response.status_code == 200
         assert get_user(client).is_authenticated is True
@@ -1584,8 +1665,14 @@ class TestPasswordChangeView:
                                     "Il doit contenir au minimum 12 caractères.",
                                     "code": "password_too_short",
                                 },
-                                {"message": "Ce mot de passe est trop courant.", "code": "password_too_common"},
-                                {"message": "Le mot de passe ne contient pas assez de caractères.", "code": ""},
+                                {
+                                    "message": "Ce mot de passe est trop courant.",
+                                    "code": "password_too_common",
+                                },
+                                {
+                                    "message": "Le mot de passe ne contient pas assez de caractères.",
+                                    "code": "",
+                                },
                             ]
                         },
                     },
@@ -1596,7 +1683,10 @@ class TestPasswordChangeView:
     def test_federated(self, caplog, client):
         application = ApplicationFactory()
         user = UserFactory(federation=Federation.PEAMA)
-        client.force_login(user, backend="inclusion_connect.oidc_federation.peama.OIDCAuthenticationBackend")
+        client.force_login(
+            user,
+            backend="inclusion_connect.oidc_federation.peama.OIDCAuthenticationBackend",
+        )
         params = {"referrer_uri": "rp_url", "referrer": application.client_id}
         change_password_url = add_url_params(reverse("accounts:change_password"), params)
         response = client.get(change_password_url)
@@ -1648,7 +1738,8 @@ class TestConfirmEmailView:
     def test_get_anonymous(self, client):
         response = client.get(reverse("accounts:confirm-email"), follow=True)
         assertRedirects(
-            response, add_url_params(reverse("accounts:login"), {"next": reverse("accounts:edit_user_info")})
+            response,
+            add_url_params(reverse("accounts:login"), {"next": reverse("accounts:edit_user_info")}),
         )
 
     def test_get_with_confirmed_email(self, client):
@@ -1722,7 +1813,11 @@ class TestConfirmEmailTokenView:
                 (
                     "inclusion_connect.auth",
                     logging.INFO,
-                    {"email": "me@mailinator.com", "user": user.pk, "event": "confirm_email_address"},
+                    {
+                        "email": "me@mailinator.com",
+                        "user": user.pk,
+                        "event": "confirm_email_address",
+                    },
                 ),
                 (
                     "inclusion_connect.auth",
@@ -1795,7 +1890,12 @@ class TestConfirmEmailTokenView:
                 (
                     "inclusion_connect.auth",
                     logging.INFO,
-                    {"email": "me@mailinator.com", "user": user.pk, "event": "login", "application": "my_application"},
+                    {
+                        "email": "me@mailinator.com",
+                        "user": user.pk,
+                        "event": "login",
+                        "application": "my_application",
+                    },
                 ),
             ],
         )
@@ -1825,7 +1925,10 @@ class TestConfirmEmailTokenView:
         with freeze_time(timezone.now() - datetime.timedelta(days=1)):
             token = email_verification_token(email)
         response = client.get(self.url(user, token))
-        assertMessages(response, [(messages.ERROR, "Le lien de vérification d’adresse e-mail a expiré.")])
+        assertMessages(
+            response,
+            [(messages.ERROR, "Le lien de vérification d’adresse e-mail a expiré.")],
+        )
         assert client.session[EMAIL_CONFIRM_KEY] == "me@mailinator.com"
         assertRedirects(response, reverse("accounts:confirm-email"))
         email_address.refresh_from_db()
@@ -1872,7 +1975,11 @@ class TestConfirmEmailTokenView:
                 (
                     "inclusion_connect.auth",
                     logging.INFO,
-                    {"email": "me@mailinator.com", "event": "confirm_email_address_error", "error": "email not found"},
+                    {
+                        "email": "me@mailinator.com",
+                        "event": "confirm_email_address_error",
+                        "error": "email not found",
+                    },
                 ),
             ],
         )
@@ -1960,7 +2067,11 @@ class TestConfirmEmailTokenView:
                 (
                     "inclusion_connect.auth",
                     logging.INFO,
-                    {"email": "new@mailinator.com", "user": user.pk, "event": "confirm_email_address"},
+                    {
+                        "email": "new@mailinator.com",
+                        "user": user.pk,
+                        "event": "confirm_email_address",
+                    },
                 ),
                 (
                     "inclusion_connect.auth",
@@ -2030,7 +2141,11 @@ class TestConfirmEmailTokenView:
                 (
                     "inclusion_connect.auth",
                     logging.INFO,
-                    {"email": "me@mailinator.com", "event": "confirm_email_address_error", "error": "email not found"},
+                    {
+                        "email": "me@mailinator.com",
+                        "event": "confirm_email_address_error",
+                        "error": "email not found",
+                    },
                 ),
             ],
         )
@@ -2116,8 +2231,14 @@ class TestChangeTemporaryPasswordView:
                                     "Il doit contenir au minimum 12 caractères.",
                                     "code": "password_too_short",
                                 },
-                                {"message": "Ce mot de passe est trop courant.", "code": "password_too_common"},
-                                {"message": "Le mot de passe ne contient pas assez de caractères.", "code": ""},
+                                {
+                                    "message": "Ce mot de passe est trop courant.",
+                                    "code": "password_too_common",
+                                },
+                                {
+                                    "message": "Le mot de passe ne contient pas assez de caractères.",
+                                    "code": "",
+                                },
                             ]
                         },
                     },
@@ -2164,6 +2285,9 @@ class TestMiddleware:
         )
         client.force_login(user)
         response = client.get(
-            add_url_params(reverse("oauth2_provider:rp-initiated-logout"), {"state": "random_string"})
+            add_url_params(
+                reverse("oauth2_provider:rp-initiated-logout"),
+                {"state": "random_string"},
+            )
         )
         assert response.status_code == 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from bs4 import BeautifulSoup
 from django.test import TestCase, client as django_client
 
 
@@ -63,3 +64,21 @@ def oidc_params():
         "state": "state",
         "nonce": "nonce",
     }
+
+
+def parse_response_to_soup(response, selector=None, no_html_body=False):
+    soup = BeautifulSoup(response.content, "html5lib", from_encoding=response.charset or "utf-8")
+    if no_html_body:
+        # If the provided HTML does not contain <html><body> tags
+        # html5lib will always add them around the response:
+        # ignore them
+        soup = soup.body
+    if selector is not None:
+        [soup] = soup.select(selector)
+    for csrf_token_input in soup.find_all("input", attrs={"name": "csrfmiddlewaretoken"}):
+        csrf_token_input["value"] = "NORMALIZED_CSRF_TOKEN"
+    if "nonce" in soup.attrs:
+        soup["nonce"] = "NORMALIZED_CSP_NONCE"
+    for csp_nonce_script in soup.find_all("script", {"nonce": True}):
+        csp_nonce_script["nonce"] = "NORMALIZED_CSP_NONCE"
+    return soup

--- a/tests/test_builtin_views.py
+++ b/tests/test_builtin_views.py
@@ -1,16 +1,22 @@
+from django.test import override_settings
 from django.urls import reverse
 
 from inclusion_connect.utils.urls import add_url_params
-from tests.conftest import Client
+from tests.conftest import Client, parse_response_to_soup
 
 
 def test_csrf_view(snapshot):
-    client = Client(enforce_csrf_checks=True)
-    response = client.post(
-        add_url_params(
-            reverse("accounts:login"),
-            {"referrer_uri": "http://go.back/there", "other_parameter": "is_ignored"},
-        ),
-        {"username": "doesnot", "password": "matter"},
-    )
-    assert str(response.content.decode()) == snapshot
+    with override_settings(MATOMO_BASE_URL="https://matomo.example.com", MATOMO_SITE_ID=1):
+        client = Client(enforce_csrf_checks=True)
+        response = client.post(
+            add_url_params(
+                reverse("accounts:login"),
+                {
+                    "referrer_uri": "http://go.back/there",
+                    "other_parameter": "is_ignored",
+                },
+            ),
+            {"username": "doesnot", "password": "matter"},
+        )
+        script_content = parse_response_to_soup(response)
+        assert str(script_content) == snapshot

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -1,6 +1,12 @@
+from django.test import override_settings
 from django.urls import reverse
+
+from tests.conftest import parse_response_to_soup
 
 
 def test_homepage(client, snapshot):
-    response = client.get(reverse("homepage"))
-    assert str(response.content.decode()) == snapshot
+    with override_settings(MATOMO_BASE_URL="https://matomo.example.com", MATOMO_SITE_ID=1):
+        response = client.get(reverse("homepage"))
+
+        script_content = parse_response_to_soup(response)
+        assert str(script_content) == snapshot


### PR DESCRIPTION
**Carte Notion**

https://www.notion.so/plateforme-inclusion/Brancher-Matomo-361aa1262ba04d89bb3c1f68b89184b6

### Pourquoi ?

Brancher le Matomo du GIP sur Inclusion Connect

### Comment <!-- optionnel -->

Code inspiré de celui des emplois, sans l'utilisation de tarteaucitron pour l'instant. Reste à vérifier si les cookies que Matomo pose nécessitent l'utilisation de tarteaucitron.

On remplace l'utilisation de `bootstrap_button` par du simple HTML car `django-bootstrap5` ne permet pas l'utilisation d'attributs `data-*` utilisés pour Matomo (à cause des - dans le nom, cf https://github.com/zostera/django-bootstrap5/issues/267 )
