### PR TITLE
Ajout de la liste des noms de domaine dans la documentation

### DIFF
--- a/docs/inclusion_connect.md
+++ b/docs/inclusion_connect.md
@@ -25,6 +25,11 @@ D'un point de vue OpenID Connect, les end-points Authorization, Registration et 
 sont identiques. La seule chose qui change est si l'utilisateur n'est pas connecté, dans ce cas on
 le redirige vers une vue différente pour chaque end-point.
 
+Le hostname dépend de l'instance utilisée :
+- https://connect.inclusion.beta.gouv.fr/ pour la production
+- https://recette.connect.inclusion.beta.gouv.fr/ pour la recette
+- http://127.0.0.1:8080 pour l'environnement local
+
 ## Détail du fonctionnement
 
 ```mermaid


### PR DESCRIPTION
Un partenaire nous fait remarquer que ce serait pratique d'ajouter cette liste.
Les urls sont de toute manière facilement récupérables depuis un partenaire, donc ce n'est pas dangereux de les mettre dans la documentation.