### PR TITLE
correctifs divers pour peama

### DIFF
--- a/inclusion_connect/accounts/forms.py
+++ b/inclusion_connect/accounts/forms.py
@@ -136,6 +136,13 @@ class RegisterForm(auth_forms.UserCreationForm):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
+        if email.endswith("@pole-emploi.fr") and settings.PEAMA_ENABLED and not settings.PEAMA_STAGING:
+            error_message = (
+                "Vous utilisez une adresse e-mail en @pole-emploi.fr. "
+                "Vous devez utiliser le bouton de connexion Pôle Emploi pour accéder au service."
+            )
+            self.log["email"] = email
+            raise forms.ValidationError(error_message)
         try:
             email_address = EmailAddress.objects.get(email=email)
         except EmailAddress.DoesNotExist:

--- a/inclusion_connect/oidc_federation/base.py
+++ b/inclusion_connect/oidc_federation/base.py
@@ -126,6 +126,9 @@ class OIDCAuthenticationBackend(ConfigMixin, auth.OIDCAuthenticationBackend):
                 log[f"new_{key}"] = new_user_data[key]
         transaction.on_commit(partial(logger.info, log))
 
+        # Remove all associated email_addresses
+        user.email_addresses.all().delete()
+
         return user
 
     def verify_claims(self, claims):

--- a/tests/oidc_federation/test_peama.py
+++ b/tests/oidc_federation/test_peama.py
@@ -173,11 +173,12 @@ class TestFederation:
         )
 
     def test_convert_existing_ic_user(self, client, requests_mock, caplog):
-        UserFactory(
+        user = UserFactory(
             email="michel@pole-emploi.fr",
             first_name="old_first_name",
             last_name="old_last_name",
         )
+        assert user.email_addresses.count() == 1
         response = client.get(reverse("oidc_federation:peama:init"))
         response, peama_data = mock_peama_oauth_dance(client, requests_mock, response.url)
         user = User.objects.get()
@@ -190,6 +191,7 @@ class TestFederation:
             "structure_pe": PEAMA_ADDITIONAL_DATA["structureTravail"],
             "site_pe": PEAMA_ADDITIONAL_DATA["siteTravail"],
         }
+        assert user.email_addresses.count() == 0
         assertRedirects(response, reverse("accounts:edit_user_info"))
         assertRecords(
             caplog,


### PR DESCRIPTION
Il faut supprimer les objets EmailAddress quand on passe à la fédération (pas besoin de valider l'adresse email)
Il faut bloquer la création de compte avec un email PE