### PR TITLE
Ne plus permettre au support de modifier des comptes super utilisateurs

### DIFF
--- a/inclusion_connect/users/admin.py
+++ b/inclusion_connect/users/admin.py
@@ -255,13 +255,14 @@ class UserAdmin(auth_admin.UserAdmin):
         fieldsets = super().get_fieldsets(request, obj)
         is_change_form = obj is not None
         if is_change_form:
-            assert fieldsets[0] == (None, {"fields": ("username", "password")})
-            assert fieldsets[1] == ("Informations personnelles", {"fields": ("first_name", "last_name", "email")})
             fieldsets = list(copy.deepcopy(fieldsets))
-            if not obj.federation:
-                fieldsets[0][1]["fields"] = ("username", "must_reset_password")
-            else:
+            assert fieldsets[0] == (None, {"fields": ("username", "password")})
+            if obj.federation or not self.has_change_permission(request, obj):
                 fieldsets[0][1]["fields"] = ("username",)
+            else:
+                fieldsets[0][1]["fields"] = ("username", "must_reset_password")
+
+            assert fieldsets[1] == ("Informations personnelles", {"fields": ("first_name", "last_name", "email")})
             fieldsets[1][1]["fields"] += ("confirm_email",)
 
             fieldsets.append(("CGU", {"fields": ["terms_accepted_at"]}))
@@ -300,3 +301,8 @@ class UserAdmin(auth_admin.UserAdmin):
                 )
             )
         )
+
+    def has_change_permission(self, request, obj=None):
+        if getattr(obj, "is_superuser", False) and not request.user.is_superuser:
+            return False
+        return super().has_change_permission(request, obj)


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Emp-cher-les-comptes-support-de-modifier-les-comptes-super-admin-858d045ab9d14fcebfbf8e18e8e1ad13?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?
Par sécurité