### PR TITLE
Supprimer les autoescapes des templates d'emails

### DIFF
--- a/inclusion_connect/templates/admin/auth/user/change_password.html
+++ b/inclusion_connect/templates/admin/auth/user/change_password.html
@@ -21,8 +21,9 @@
                     </p>
                 {% endif %}
 
+
                 <p>
-                    {% blocktranslate with username=original %}Enter a new password for the user <strong>{{ username }}</strong>.{% endblocktranslate %}
+                    Saisissez un nouveau mot de passe pour l’utilisateur <strong>{{ original|force_escape }}</strong>.
                 </p>
 
                 <fieldset class="module aligned">

--- a/inclusion_connect/templates/layout/base_email_body.html
+++ b/inclusion_connect/templates/layout/base_email_body.html
@@ -1,11 +1,7 @@
-{% autoescape off %}
-
-    <p>Bonjour,</p>
-    {% block body %}{% endblock %}
-    <p>
-        ---
-        <br>
-        L’équipe d’inclusion connect
-    </p>
-
-{% endautoescape %}
+<p>Bonjour,</p>
+{% block body %}{% endblock %}
+<p>
+    ---
+    <br>
+    L’équipe d’inclusion connect
+</p>

--- a/inclusion_connect/templates/layout/base_email_body.txt
+++ b/inclusion_connect/templates/layout/base_email_body.txt
@@ -1,4 +1,4 @@
-{% autoescape off %}Bonjour,
+Bonjour,
 {% block body %}{% endblock %}
 ---
-L’équipe d’inclusion connect{% endautoescape %}
+L’équipe d’inclusion connect

--- a/inclusion_connect/templates/registration/email_verification_subject.txt
+++ b/inclusion_connect/templates/registration/email_verification_subject.txt
@@ -1,3 +1,1 @@
-{% autoescape off %}
 Vérification de l’adresse e-mail
-{% endautoescape %}

--- a/inclusion_connect/templates/registration/password_reset_subject.txt
+++ b/inclusion_connect/templates/registration/password_reset_subject.txt
@@ -1,3 +1,1 @@
-{% autoescape off %}
 Réinitialisation de votre mot de passe
-{% endautoescape %}

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -445,14 +445,14 @@ class TestRegisterView:
             "L’équipe d’inclusion connect\n"
         )
         assert email.alternatives[0][0] == (
-            "\n\n    <p>Bonjour,</p>\n    \n    "
+            "<p>Bonjour,</p>\n\n    "
             "<p>\n        Une demande de\n        \n            création\n        \n        "
             "de compte a été effectuée avec votre adresse\n"
             "        e-mail. Si vous êtes à l’origine de cette requête&nbsp;:\n        <br>\n    </p>\n    <p>\n"
             f'        <a href="{verify_link}">Vérifiez votre adresse email</a>.\n    </p>\n\n    '
             "<p>Ce lien expire dans 1 jour.</p>\n\n    "
             "<p>\n        <i>Si vous n’êtes pas à l’origine de cette demande, veuillez ignorer ce message.</i>\n    "
-            "</p>\n\n    <p>\n        ---\n        <br>\n        L’équipe d’inclusion connect\n    </p>\n\n\n"
+            "</p>\n\n<p>\n    ---\n    <br>\n    L’équipe d’inclusion connect\n</p>\n"
         )
         assertRecords(
             caplog,
@@ -1491,14 +1491,14 @@ class TestEditUserInfoView:
             "L’équipe d’inclusion connect\n"
         )
         assert email.alternatives[0][0] == (
-            "\n\n    <p>Bonjour,</p>\n    \n    "
+            "<p>Bonjour,</p>\n\n    "
             "<p>\n        Une demande de\n        \n            modification\n        \n        "
             "de compte a été effectuée avec votre adresse\n"
             "        e-mail. Si vous êtes à l’origine de cette requête&nbsp;:\n        <br>\n    </p>\n    <p>\n"
             f'        <a href="{verify_link}">Vérifiez votre adresse email</a>.\n    </p>\n\n    '
             "<p>Ce lien expire dans 1 jour.</p>\n\n    "
             "<p>\n        <i>Si vous n’êtes pas à l’origine de cette demande, veuillez ignorer ce message.</i>\n    "
-            "</p>\n\n    <p>\n        ---\n        <br>\n        L’équipe d’inclusion connect\n    </p>\n\n\n"
+            "</p>\n\n<p>\n    ---\n    <br>\n    L’équipe d’inclusion connect\n</p>\n"
         )
 
     def test_edit_email_case(self, caplog, client):

--- a/tests/users/__snapshots__/test_admin.ambr
+++ b/tests/users/__snapshots__/test_admin.ambr
@@ -136,6 +136,7 @@
                   
                   
   
+  
                   <p>
                       Saisissez un nouveau mot de passe pour l’utilisateur <strong>John Doe — admin@mailinator.net</strong>.
                   </p>


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/V-rifier-si-on-peut-v-rifier-les-autoescapes-des-emails-6aea0d203db647f7b131d5ed7bac27d7?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Potentiel problème de sécurité