### PR TITLE
Rendre le slash final optionnel

### DIFF
--- a/docs/inclusion_connect.md
+++ b/docs/inclusion_connect.md
@@ -13,12 +13,12 @@ Le format des urls est le suivant :
 
 |               |                                       |
 |           --- | ---                                   |
-| Authorization | https://{hostname}/auth/authorize/    |
-| Registration  | https://{hostname}/auth/register/     |
-| Activation    | https://{hostname}/auth/activate/     |
-| Token         | https://{hostname}/auth/token/        |
-| UserInfo      | https://{hostname}/auth/userinfo/     |
-| Logout        | https://{hostname}/auth/logout/       |
+| Authorization | https://{hostname}/auth/authorize     |
+| Registration  | https://{hostname}/auth/register      |
+| Activation    | https://{hostname}/auth/activate      |
+| Token         | https://{hostname}/auth/token         |
+| UserInfo      | https://{hostname}/auth/userinfo      |
+| Logout        | https://{hostname}/auth/logout        |
 
 
 D'un point de vue OpenID Connect, les end-points Authorization, Registration et Activation
@@ -36,19 +36,19 @@ Le hostname dépend de l'instance utilisée :
 sequenceDiagram
 Note right of Utilisateur: L'utilisateur clique sur le bouton "Inclusion Connect"
 Utilisateur ->> FS: ;
-FS -->> Utilisateur: Redirect 302 <IC_URL>/auth/authorize/
+FS -->> Utilisateur: Redirect 302 <IC_URL>/auth/authorize
 Utilisateur ->> Inclusion Connect: GET <IC_URL>/auth/authorize.
 Inclusion Connect -->> Utilisateur: Redirect 302 <FS_URL>/<URL_CALLBACK>
 Utilisateur ->> FS: GET <FS_URL>/<URL_CALLBACK>
-FS ->> Inclusion Connect: POST <IC_URL>/auth/token/
+FS ->> Inclusion Connect: POST <IC_URL>/auth/token
 Inclusion Connect -->> FS: HTTP Response 200
-FS ->> Inclusion Connect: POST <IC_URL>/auth/userinfo/
+FS ->> Inclusion Connect: POST <IC_URL>/auth/userinfo
 Inclusion Connect -->> FS: HTTP Response 200
 FS -->> Utilisateur: Redirect 302 <FS_URL>/page_authentifée
 Note right of Utilisateur: Plus tard l'utilisateur se déconnecte du fournisseur de service
 Utilisateur ->> FS: ;
-FS -->> Utilisateur: Redirect 302 <IC_URL>/auth/logout/
-Utilisateur ->> Inclusion Connect: GET <IC_URL>/auth/logout/
+FS -->> Utilisateur: Redirect 302 <IC_URL>/auth/logout
+Utilisateur ->> Inclusion Connect: GET <IC_URL>/auth/logout
 Inclusion Connect -->> Utilisateur: Redirect 302 <FS_URL>/<POST_LOGOUT_REDIRECT_URI>
 Utilisateur ->> FS: GET <FS_URL>/<POST_LOGOUT_REDIRECT_URI>
 ```
@@ -70,7 +70,7 @@ Le détail des flux peut être trouvé en anglais ici :
 
 #### Requête (Authentification)
 
-- URL : `https://{hostname}/auth/authorize/?response_type=code&client_id=<CLIENT_ID>&redirect_uri=<FS_URL>%2F<URL_CALLBACK>&scope=<SCOPES>&state=><STATE>&nonce=<NONCE>`
+- URL : `https://{hostname}/auth/authorize?response_type=code&client_id=<CLIENT_ID>&redirect_uri=<FS_URL>%2F<URL_CALLBACK>&scope=<SCOPES>&state=><STATE>&nonce=<NONCE>`
 - Méthode : GET
 
 Les paramètres sont les suivants :
@@ -93,7 +93,7 @@ Une fois sur Inclusion Connect, il y a 3 possibilités.
 
 Il est possible d'utiliser l'endpoint _Registration_ pour que l'utilisateur arrive directement sur cette seconde page.
 
-- URL : `https://{hostname}/auth/register/?response_type=code&client_id=<CLIENT_ID>&redirect_uri=<FS_URL>%2F<URL_CALLBACK>&scope=<SCOPES>&state=><STATE>&nonce=<NONCE>`
+- URL : `https://{hostname}/auth/register?response_type=code&client_id=<CLIENT_ID>&redirect_uri=<FS_URL>%2F<URL_CALLBACK>&scope=<SCOPES>&state=><STATE>&nonce=<NONCE>`
 - Méthode : GET
 
 Les paramètres sont les mêmes que pour l'Authentification.
@@ -102,7 +102,7 @@ Les paramètres sont les mêmes que pour l'Authentification.
 
 Il est possible d'utiliser l'endpoint _Activation_ pour que l'utilisateur arrive directement sur une page de création de compte pré-remplie.
 
-- URL : `https://{hostname}/auth/activate/?response_type=code&client_id=<CLIENT_ID>&redirect_uri=<FS_URL>%2F<URL_CALLBACK>&scope=<SCOPES>&state=><STATE>&nonce=<NONCE>`
+- URL : `https://{hostname}/auth/activate?response_type=code&client_id=<CLIENT_ID>&redirect_uri=<FS_URL>%2F<URL_CALLBACK>&scope=<SCOPES>&state=><STATE>&nonce=<NONCE>`
 - Méthode : GET
 
 Les paramètres sont les mêmes que pour l'Authentification, plus :
@@ -144,7 +144,7 @@ Les paramètres sont les suivants :
 
 #### Requête
 
-- URL : `https://{hostname}/auth/token/`
+- URL : `https://{hostname}/auth/token`
 - Méthode : POST
 - Header attendu: `Content-Type: application/x-www-form-urlencoded`
 - Body: au format `key1=value1&key2=value2` (adapté au content-type `application/x-www-form-urlencoded` )
@@ -207,7 +207,7 @@ sont déjà présentent dans l'id_token.
 
 #### Requête
 
-- URL :  `https://{hostname}/auth/userinfo/`
+- URL :  `https://{hostname}/auth/userinfo`
 - Méthode : GET. La transmission de l'_access_token_ DOIT se faire dans le header `Authorization : Bearer <Token>`.
 
 #### Réponse
@@ -233,11 +233,11 @@ Cela peut être fait de deux manières :
 
 #### Sans confirmation
 
-On redirige l'utilisateur sur `https://{hostname}/auth/logout/?state=<STATE>&id_token_hint=<ID_TOKEN>&post_logout_redirect_uri=<FS_URL>%2F<POST_LOGOUT_REDIRECT_URI>`
+On redirige l'utilisateur sur `https://{hostname}/auth/logout?state=<STATE>&id_token_hint=<ID_TOKEN>&post_logout_redirect_uri=<FS_URL>%2F<POST_LOGOUT_REDIRECT_URI>`
 qui sera ensuite redirigé vers l'url passée avec le paramètre **post_logout_redirect_uri**.
 
 
 #### Avec confirmation
 
-Si le `STATE` et/ou l'`ID_TOKEN` ne sont pas disponibles, il est possible de déconnecter l'utilisateur avec une redirection  vers `https://{hostname}/auth/logout/?client_id=<CLIENT_ID>&post_logout_redirect_uri=<FS_URL>%2F<POST_LOGOUT_REDIRECT_URI>`.
+Si le `STATE` et/ou l'`ID_TOKEN` ne sont pas disponibles, il est possible de déconnecter l'utilisateur avec une redirection vers `https://{hostname}/auth/logout?client_id=<CLIENT_ID>&post_logout_redirect_uri=<FS_URL>%2F<POST_LOGOUT_REDIRECT_URI>`.
 Dans ce cas, l'utilisateur devra confirmer sa volonté de se deconnecter d'Inclusion Connect et sera ensuite redirigé vers l'url passée avec le paramètre **post_logout_redirect_uri**.

--- a/docs/user_journey.md
+++ b/docs/user_journey.md
@@ -16,9 +16,9 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/authorize/?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
+    http://0.0.0.0:8080/auth/authorize?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
 
-    L’url est celle de l’endpoint Authorization: `https://{hostname}/auth/authorize/`
+    L’url est celle de l’endpoint Authorization: `https://{hostname}/auth/authorize`
 
     Les paramètres à renseigner sont:
 
@@ -42,9 +42,9 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/register/?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W&from=emplois
+    http://0.0.0.0:8080/auth/register?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W&from=emplois
 
-    L’url est celle de l’endpoint Registration: `https://{hostname}/auth/register/`
+    L’url est celle de l’endpoint Registration: `https://{hostname}/auth/register`
 
     Les paramètres à renseigner sont:
 
@@ -88,9 +88,9 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/authorize/?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
+    http://0.0.0.0:8080/auth/authorize?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
 
-    L’url est celle de l’endpoint Authorization: `https://{hostname}/auth/authorize/`
+    L’url est celle de l’endpoint Authorization: `https://{hostname}/auth/authorize`
 
     Les paramètres à renseigner sont:
 
@@ -120,9 +120,9 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/authorize/?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
+    http://0.0.0.0:8080/auth/authorize?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=0xGVKT6eO9NT%3Aarn7NqGqozXjsvio5CAmU2lpoF2nJmLTlU9OuaHAtOg&nonce=r04v4u8sT05W
 
-    L’url est celle de l’endpoint Authorization: `https://{hostname}/auth/authorize/`
+    L’url est celle de l’endpoint Authorization: `https://{hostname}/auth/authorize`
 
     Les paramètres à renseigner sont:
 
@@ -178,9 +178,9 @@ Les URLs de retour sont configurées pour un setup local des emplois de l’incl
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/activate/?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=mJGvp3qwBMkD%3AYedrAibh8pHw0yx3mY8-L2Zp-vhLe8D-rL2aClHm9zQ&nonce=CbBAoMxEUIJR&login_hint=mon%40email.com&lastname=Nom&firstname=Pr%C3%A9nom
+    http://0.0.0.0:8080/auth/activate?response_type=code&client_id=local_inclusion_connect&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Finclusion_connect%2Fcallback&scope=openid+profile+email&state=mJGvp3qwBMkD%3AYedrAibh8pHw0yx3mY8-L2Zp-vhLe8D-rL2aClHm9zQ&nonce=CbBAoMxEUIJR&login_hint=mon%40email.com&lastname=Nom&firstname=Pr%C3%A9nom
 
-    L’url est celle de l’endpoint Registration: `https://{hostname}/auth/activate/`
+    L’url est celle de l’endpoint Registration: `https://{hostname}/auth/activate`
 
     Les paramètres à renseigner sont:
 
@@ -214,7 +214,7 @@ La déconnexion peut être faite de deux manières:
 
     Pas d’accès direct vu qu’il faut l’`id_token`
 
-    L’url est celle de l’endpoint Logout: `https://{hostname}/auth/logout/`
+    L’url est celle de l’endpoint Logout: `https://{hostname}/auth/logout`
 
     Les paramètres à renseigner sont:
 
@@ -233,9 +233,9 @@ La déconnexion peut être faite de deux manières:
   - <details>
     <summary>**[DEV]** : Url et paramètres d’accès direct à la page:</summary>
 
-    http://0.0.0.0:8080/auth/logout/?client_id=local_inclusion_connect&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8000
+    http://0.0.0.0:8080/auth/logout?client_id=local_inclusion_connect&post_logout_redirect_uri=http%3A%2F%2Flocalhost%3A8000
 
-    L’url est celle de l’endpoint Logout: `https://{hostname}/auth/logout/`
+    L’url est celle de l’endpoint Logout: `https://{hostname}/auth/logout`
 
     Les paramètres à renseigner sont:
 

--- a/inclusion_connect/oidc_overrides/urls.py
+++ b/inclusion_connect/oidc_overrides/urls.py
@@ -7,19 +7,19 @@ from inclusion_connect.oidc_overrides import views
 app_name = "oauth2_provider"
 
 urlpatterns = [
-    re_path(r"^authorize/", views.AuthorizationView.as_view(), name="authorize"),
-    re_path(r"^register/", views.RegistrationView.as_view(), name="register"),
-    re_path(r"^activate/", views.ActivationView.as_view(), name="activate"),
-    re_path(r"^token/$", oauth2_views.TokenView.as_view(), name="token"),
-    re_path(r"^revoke_token/$", oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
-    re_path(r"^introspect/$", oauth2_views.IntrospectTokenView.as_view(), name="introspect"),
+    re_path(r"^authorize/?", views.AuthorizationView.as_view(), name="authorize"),
+    re_path(r"^register/?", views.RegistrationView.as_view(), name="register"),
+    re_path(r"^activate/?", views.ActivationView.as_view(), name="activate"),
+    re_path(r"^token/?$", oauth2_views.TokenView.as_view(), name="token"),
+    re_path(r"^revoke_token/?$", oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
+    re_path(r"^introspect/?$", oauth2_views.IntrospectTokenView.as_view(), name="introspect"),
     # OIDC urls
     re_path(
-        r"^\.well-known/openid-configuration/$",
+        r"^\.well-known/openid-configuration/?$",
         oauth2_views.ConnectDiscoveryInfoView.as_view(),
         name="oidc-connect-discovery-info",
     ),
     re_path(r"^\.well-known/jwks.json$", oauth2_views.JwksInfoView.as_view(), name="jwks-info"),
-    re_path(r"^userinfo/$", oauth2_views.UserInfoView.as_view(), name="user-info"),
-    re_path(r"^logout/", views.LogoutView.as_view(), name="rp-initiated-logout"),
+    re_path(r"^userinfo/?$", oauth2_views.UserInfoView.as_view(), name="user-info"),
+    re_path(r"^logout/?", views.LogoutView.as_view(), name="rp-initiated-logout"),
 ]

--- a/tests/oidc_overrides/tests.py
+++ b/tests/oidc_overrides/tests.py
@@ -152,7 +152,7 @@ class TestLogoutView:
         assertRecords(
             caplog,
             [
-                ("django.request", logging.WARNING, "Bad Request: /auth/logout/"),
+                ("django.request", logging.WARNING, "Bad Request: /auth/logout"),
                 (
                     "inclusion_connect.oidc",
                     logging.INFO,
@@ -218,7 +218,7 @@ class TestLogoutView:
         assertRecords(
             caplog,
             [
-                ("django.request", logging.WARNING, "Bad Request: /auth/logout/"),
+                ("django.request", logging.WARNING, "Bad Request: /auth/logout"),
                 (
                     "inclusion_connect.oidc",
                     logging.INFO,
@@ -539,6 +539,12 @@ def test_pkce_flow(client, oidc_params, caplog):
     user = UserFactory()
     client.force_login(user)
     oidc_complete_flow(client, user, oidc_params, caplog, use_pkce=True)
+
+
+def test_with_trailing_slash(client, oidc_params, caplog):
+    user = UserFactory()
+    client.force_login(user)
+    oidc_complete_flow(client, user, oidc_params, caplog, use_pkce=True, with_trailing_slash=True)
 
 
 def test_user_application_link(client, oidc_params):


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Rendre-le-slash-final-optionnel-b38e45c2ee214f069b63ea8290bd5deb?pvs=4

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Simplifier le branchement de nouveaux utilisateurs