### PR TITLE
Créer un document security.txt

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+Communication en français ou en anglais.
+*Please use French or English for communications.*
+*English version below.*
+
+# Révéler un problème de sécurité
+
+Merci de ne pas révéler les problèmes de sécurité sur GitHub, mais de suivre la
+politique définie par le document
+[security.txt](https://connect.inclusion.beta.gouv.fr/.well-known/security.txt).
+
+Vous devriez recevoir une réponse sous 1 jour ouvré.
+
+Merci d’inclure autant d’éléments que possible dans votre rapport pour nous
+aider à identifier et reproduire le problème :
+
+- Type de problème (e.g. dépassement de mémoire, injection SQL, cross-site
+  scripting, etc.)
+- Chemin vers les fichiers sources liés au problème
+- URL, branches / tags ou commit affecté par le problème
+- Votre configuration (compte utilisateur, etc.)
+- Instructions pas à pas pour reproduire le problème
+- Impact du problème, dont des pistes pour qu’un utilisateur malveillant
+  exploite la vulnérabilité
+
+# Reporting Security Issues
+
+Please do not report security vulnerabilities through GitHub. Instead, follow
+the policy defined by the
+[security.txt](https://connect.inclusion.beta.gouv.fr/.well-known/security.txt).
+
+You should receive a response on the next working day.
+
+Please include the requested information listed below (as much as you can
+provide) to help us better understand the nature and scope of the possible
+issue:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue

--- a/inclusion_connect/templates/security.txt
+++ b/inclusion_connect/templates/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:tech@inclusion.beta.gouv.fr
+Expires: 2024-06-19T12:00:00.000Z
+Preferred-Languages: fr,en
+Canonical: https://connect.inclusion.beta.gouv.fr/.well-known/security.txt
+Policy: https://github.com/gip-inclusion/inclusion-connect/blob/main/.github/SECURITY.md

--- a/inclusion_connect/urls.py
+++ b/inclusion_connect/urls.py
@@ -34,6 +34,8 @@ urlpatterns = [
     path("federation/", include("inclusion_connect.oidc_federation.urls", "oidc_federation")),
     # Mandatory accesibilty page
     path("accessibility/", views.accessibility, name="accessibility"),
+    # security.txt page
+    path(".well-known/security.txt", views.security_txt, name="security-txt"),
 ]
 
 if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:

--- a/inclusion_connect/views.py
+++ b/inclusion_connect/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.urls import reverse
+from django.views.decorators.http import require_safe
 
 from inclusion_connect.utils.urls import add_url_params
 
@@ -19,3 +20,14 @@ def home(request, template_name="homepage.html", **kwargs):
 
 def accessibility(request, template_name="accessibility.html", **kwargs):
     return render(request, template_name)
+
+
+@require_safe
+def security_txt(request, template_name="security.txt", **kwargs):
+    # https://www.rfc-editor.org/rfc/rfc9116
+    # https://securitytxt.org/ can be helpful in generating the document.
+    return render(
+        request,
+        template_name,
+        content_type="text/plain; charset=utf-8",
+    )


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Ajouter-un-security-txt-d87d78a7fe5d4157a98dcfa95cb7ac47**

### Pourquoi ?

Faciliter la communication de problèmes de sécurité.
https://www.rfc-editor.org/rfc/rfc9116