### PR TITLE
Surveiller les erreurs JS avec Sentry

### DIFF
--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -386,8 +386,13 @@ CSP_STYLE_SRC = [
     "'self'",
 ]
 CSP_FONT_SRC = ["'self'"]
-CSP_SCRIPT_SRC = ["'self'"]
-CSP_CONNECT_SRC = ["'self'"]
+CSP_SCRIPT_SRC = [
+    "'self'",
+    # https://docs.sentry.io/platforms/javascript/install/loader/#content-security-policy
+    "https://browser.sentry-cdn.com",
+    "https://js.sentry-cdn.com",
+]
+CSP_CONNECT_SRC = ["'self'", "*.sentry.io"]
 CSP_OBJECT_SRC = ["'none'"]
 CSP_INCLUDE_NONCE_IN = ["script-src"]
 CSP_REPORT_URI = os.getenv("CSP_REPORT_URI", None)

--- a/inclusion_connect/templates/layout/base.html
+++ b/inclusion_connect/templates/layout/base.html
@@ -14,6 +14,10 @@
         <link rel="stylesheet" href="{% static "vendor/theme-inclusion/stylesheets/app.css" %}" type="text/css">
         <link rel="stylesheet" href="{% static "css/inclusion_connect.css" %}" type="text/css">
 
+        {% if not debug %}
+            <script src="https://js.sentry-cdn.com/d9163858ff954fc9a789fcb17662e1d2.min.js" crossorigin="anonymous"></script>
+        {% endif %}
+
         {% block extra_head %}{% endblock %}
     </head>
     <body>

--- a/tests/__snapshots__/test_builtin_views.ambr
+++ b/tests/__snapshots__/test_builtin_views.ambr
@@ -14,6 +14,10 @@
           <link href="/static/css/inclusion_connect.css" rel="stylesheet" type="text/css"/>
   
           
+              <script crossorigin="anonymous" src="https://js.sentry-cdn.com/d9163858ff954fc9a789fcb17662e1d2.min.js"></script>
+          
+  
+          
       </head>
       <body>
           

--- a/tests/__snapshots__/test_homepage.ambr
+++ b/tests/__snapshots__/test_homepage.ambr
@@ -14,6 +14,10 @@
           <link href="/static/css/inclusion_connect.css" rel="stylesheet" type="text/css"/>
   
           
+              <script crossorigin="anonymous" src="https://js.sentry-cdn.com/d9163858ff954fc9a789fcb17662e1d2.min.js"></script>
+          
+  
+          
       </head>
       <body>
           


### PR DESCRIPTION
### Pourquoi ?

Être informés des erreurs de JS sur les pages.

### Comment ?

Par le loader automagique de Sentry.
