### PR TITLE
Correction d’échecs de tests/test_logging.py::test_log_formatting

### DIFF
--- a/tests/__snapshots__/test_logging.ambr
+++ b/tests/__snapshots__/test_logging.ambr
@@ -2,7 +2,6 @@
 # name: test_log_formatting[log serialized as JSON with metadata]
   '''
   {"key": "value", "other_key": "value", "@timestamp": "2023-05-05T11:11:11Z", "name": "inclusion_connect", "levelname": "INFO"}
-  INFO:inclusion_connect:{'key': 'value', 'other_key': 'value'}
   
   '''
 # ---

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,3 +1,4 @@
+import io
 import logging
 from unittest import mock
 
@@ -10,10 +11,10 @@ from inclusion_connect.logging import ElasticSearchHandler
 def test_log_formatting(snapshot):
     logger = logging.getLogger("inclusion_connect")  # Root logger for IC.
     [handler] = logger.handlers
-    logger.info({"key": "value", "other_key": "value"})
-    stream = handler.stream
-    stream.seek(0)
-    assert stream.read() == snapshot(name="log serialized as JSON with metadata")
+    with io.StringIO() as capture_stream:
+        handler.setStream(capture_stream)
+        logger.info({"key": "value", "other_key": "value"})
+        assert capture_stream.getvalue() == snapshot(name="log serialized as JSON with metadata")
 
 
 @mock.patch("inclusion_connect.logging.bulk")


### PR DESCRIPTION
Running the test locally caused:
```
    @freeze_time("2023-05-05 11:11:11")
    def test_log_formatting(snapshot):
        logger = logging.getLogger("inclusion_connect")  # Root logger for IC.
        [handler] = logger.handlers
        with io.StringIO() as capture_stream:
            handler.setStream(capture_stream)
            logger.info({"key": "value", "other_key": "value"})
>           assert capture_stream.getvalue() == snapshot(name="log serialized as JSON with metadata")
E           assert [+ received] == [- snapshot]
E               '''
E               {"key": "value", "other_key": "value", "@timestamp": "2023-05-05T11:11:11Z", "name": "inclusion_connect", "level
name": "INFO"}
E             - INFO:inclusion_connect:{'key': 'value', 'other_key': 'value'}
E
E               '''
```

```
INFO:inclusion_connect:{'key': 'value', 'other_key': 'value'}
```
is only present when the environment variable `POSTGRESQL_ADDON_URI` is
missing. That’s because dj-database-url uses logging.warning() [1] to
warn when its database URL variable is missing. That installs a default
handler on the root logger, and that default handler writes to the
console. When the variable is defined, the warning is not issued and the
logging module does not configure the root handler.

[1] https://github.com/jazzband/dj-database-url/blob/86f04ef5c6dac24764af73068b80655d7b26510c/dj_database_url/__init__.py#L69
