### PR TITLE
Bloquer l’inscription et l’auth avec id/mdp pour francetravail.fr

### DIFF
--- a/inclusion_connect/accounts/forms.py
+++ b/inclusion_connect/accounts/forms.py
@@ -14,6 +14,7 @@ from inclusion_connect.users.models import EmailAddress, User
 
 EMAIL_FIELDS_WIDGET_ATTRS = {"placeholder": "nom@domaine.fr", "autocomplete": "email"}
 PASSWORD_PLACEHOLDER = "**********"
+FRANCETRAVAIL_EMAIL_SUFFIX = ("@pole-emploi.fr", "@francetravail.fr")
 
 
 class LoginForm(forms.Form):
@@ -42,7 +43,7 @@ class LoginForm(forms.Form):
             user = User.objects.filter(email=email).first()
             if (
                 user
-                and user.email.endswith("@pole-emploi.fr")
+                and user.email.endswith(FRANCETRAVAIL_EMAIL_SUFFIX)
                 and settings.PEAMA_ENABLED
                 and not settings.PEAMA_STAGING
             ):
@@ -136,9 +137,10 @@ class RegisterForm(auth_forms.UserCreationForm):
 
     def clean_email(self):
         email = self.cleaned_data["email"]
-        if email.endswith("@pole-emploi.fr") and settings.PEAMA_ENABLED and not settings.PEAMA_STAGING:
+        if email.endswith(FRANCETRAVAIL_EMAIL_SUFFIX) and settings.PEAMA_ENABLED and not settings.PEAMA_STAGING:
+            suffix = email.rsplit("@", maxsplit=1)[-1]
             error_message = (
-                "Vous utilisez une adresse e-mail en @pole-emploi.fr. "
+                f"Vous utilisez une adresse e-mail en @{suffix}. "
                 "Vous devez utiliser le bouton de connexion Pôle Emploi pour accéder au service."
             )
             self.log["email"] = email

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -327,11 +327,12 @@ class TestLoginView:
             "Votre compte est relié à Pôle emploi. Merci de vous connecter avec ce service.",
         )
 
-    def test_pole_emploi_user_cannot_use_login_password(self, client, caplog):
+    @pytest.mark.parametrize("email", ["michel@pole-emploi.fr", "michel@francetravail.fr"])
+    def test_pole_emploi_user_cannot_use_login_password(self, client, caplog, email):
         redirect_url = reverse("oauth2_provider:rp-initiated-logout")
         url = add_url_params(reverse("accounts:login"), {"next": redirect_url})
         user = UserFactory(
-            email="michel@pole-emploi.fr",
+            email=email,
             first_name="old_first_name",
             last_name="old_last_name",
         )
@@ -728,7 +729,14 @@ class TestRegisterView:
             "L’équipe d’inclusion connect\n"
         )
 
-    def test_pole_emploi_user_register_with_django(self, client, caplog):
+    @pytest.mark.parametrize(
+        "email,suffix",
+        [
+            ("michel@pole-emploi.fr", "@pole-emploi.fr"),
+            ("michel@francetravail.fr", "@francetravail.fr"),
+        ],
+    )
+    def test_pole_emploi_user_register_with_django(self, client, caplog, email, suffix):
         redirect_url = reverse("oauth2_provider:rp-initiated-logout")
         url = add_url_params(reverse("accounts:register"), {"next": redirect_url})
 
@@ -740,7 +748,7 @@ class TestRegisterView:
         response = client.post(
             url,
             data={
-                "email": "michel@pole-emploi.fr",
+                "email": email,
                 "first_name": "John",
                 "last_name": "Backy",
                 "password1": DEFAULT_PASSWORD,
@@ -756,12 +764,12 @@ class TestRegisterView:
                     "inclusion_connect.auth",
                     logging.INFO,
                     {
-                        "email": "michel@pole-emploi.fr",
+                        "email": email,
                         "event": "register_error",
                         "errors": {
                             "email": [
                                 {
-                                    "message": "Vous utilisez une adresse e-mail en @pole-emploi.fr. "
+                                    "message": f"Vous utilisez une adresse e-mail en {suffix}. "
                                     "Vous devez utiliser le bouton de connexion Pôle Emploi pour accéder au service.",
                                     "code": "",
                                 }
@@ -773,7 +781,7 @@ class TestRegisterView:
         )
         assertContains(
             response,
-            "Vous utilisez une adresse e-mail en @pole-emploi.fr. "
+            f"Vous utilisez une adresse e-mail en {suffix}. "
             "Vous devez utiliser le bouton de connexion Pôle Emploi pour accéder au service",
         )
 


### PR DESCRIPTION
Utiliser PEAMA.
