### PR TITLE
Empêcher les comptes en @pole-emploi.fr ou @francetravail.fr de reinitialiser leur mot de passe

### DIFF
--- a/inclusion_connect/accounts/forms.py
+++ b/inclusion_connect/accounts/forms.py
@@ -222,6 +222,17 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
                 html_email_template_name="registration/password_reset_body_federation.html",
             )
 
+    def clean_email(self):
+        email = self.cleaned_data["email"]
+        if email.endswith(FRANCETRAVAIL_EMAIL_SUFFIX) and settings.PEAMA_ENABLED and not settings.PEAMA_STAGING:
+            suffix = email.rsplit("@", maxsplit=1)[-1]
+            error_message = (
+                f"Vous utilisez une adresse e-mail en @{suffix}. "
+                "Vous devez utiliser le bouton de connexion France Travail pour accéder au service."
+            )
+            raise ValidationError(error_message)
+        return email
+
 
 class SetPasswordForm(auth_forms.SetPasswordForm):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
### Pourquoi ?

Cela leur permet de se connecter ...

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

