### PR TITLE
Ajout d'un setting pour bloquer la création de compte

### DIFF
--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -65,6 +65,14 @@ class LoginView(OIDCSessionMixin, auth_views.LoginView):
 class BaseUserCreationView(OIDCSessionMixin, CreateView):
     form_class = forms.RegisterForm
 
+    def get_template_names(self):
+        return "no_register.html" if settings.FREEZE_ACCOUNTS else super().get_template_names()
+
+    def post(self, request, *args, **kwargs):
+        if settings.FREEZE_ACCOUNTS:
+            return HttpResponseForbidden()
+        return super().post(request, *args, **kwargs)
+
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
         kwargs["log"] = log_data(self.request)

--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -460,6 +460,8 @@ class EditUserInfoView(MyAccountMixin, UpdateView):
         return response
 
     def post(self, request, *args, **kwargs):
+        if settings.FREEZE_ACCOUNTS:
+            return HttpResponseForbidden()
         if self.get_object().federation:
             return HttpResponseForbidden()
         return super().post(request, *args, **kwargs)

--- a/inclusion_connect/accounts/views.py
+++ b/inclusion_connect/accounts/views.py
@@ -333,6 +333,8 @@ class ConfirmEmailTokenView(View):
         return http.urlsafe_base64_decode(encoded_email).decode()
 
     def get(self, request, uidb64, token):
+        if settings.FREEZE_ACCOUNTS:
+            return render(request, "no_confirm_email.html")
         try:
             uid = uuid.UUID(http.urlsafe_base64_decode(uidb64).decode())
         except (TypeError, ValueError, OverflowError) as e:

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -423,3 +423,9 @@ PEAMA_USER_ENDPOINT = os.getenv("PEAMA_USER_ENDPOINT")
 PEAMA_SCOPES = os.getenv("PEAMA_SCOPES")
 PEAMA_JWKS_ENDPOINT = os.getenv("PEAMA_JWKS_ENDPOINT")
 PEAMA_LOGOUT_ENDPOINT = os.getenv("PEAMA_LOGOUT_ENDPOINT")
+
+# ProConect mirgation
+# -------------------
+
+FREEZE_ACCOUNTS = os.getenv("FREEZE_ACCOUNTS")
+MIGRATION_PAGE_URL = "https://gip-inclusion.notion.site/5cfeffaf5d634a1a8275cdcf757be2f8"

--- a/inclusion_connect/templates/edit_user_info.html
+++ b/inclusion_connect/templates/edit_user_info.html
@@ -4,7 +4,28 @@
 {% block section_title %}Informations générales{% endblock %}
 
 {% block content %}
-    {% if user.federation %}
+    {% if FREEZE_ACCOUNTS %}
+        <div class="alert alert-warning">
+            {% if request.user.federation == "peama" %}
+                <p class="mb-0">
+                    <b>Compte agent France Travail</b>
+                </p>
+                <p class="mb-0">Vous ne pouvez pas modifier ces informations depuis votre espace Inclusion Connect.</p>
+            {% else %}
+                <p class="mb-0">
+                    Depuis le 1er octobre 2024, date du passage à ProConnect vous ne pouvez plus modifier vos informations personnelles (Prénom, Nom, E-mail) depuis votre espace Inclusion Connect.
+                </p>
+                <a href="{{ MIGRATION_PAGE_URL }}" target="_blank" rel="noopener">Besoin d’aide ?</a>
+            {% endif %}
+        </div>
+        <div>
+            Prénom : <strong>{{ request.user.first_name }}</strong>
+            <br>
+            Nom : <strong>{{ request.user.last_name }}</strong>
+            <br>
+            Adresse e-mail : <strong>{{ request.user.email }}</strong>
+        </div>
+    {% elif user.federation %}
         <div class="alert alert-warning">
             {% if user.federation == "peama" %}
                 <p class="mb-0">

--- a/inclusion_connect/templates/login.html
+++ b/inclusion_connect/templates/login.html
@@ -4,10 +4,12 @@
 
 {% block content %}
 
-    <div class="alert alert-info">
-        Courant novembre 2024, <strong>ProConnect</strong> remplacera Inclusion Connect sur les services numériques de l’inclusion !
-        Vous recevrez des e-mails d’information tout au long de l’été et à la rentrée.
-    </div>
+    {% if not FREEZE_ACCOUNTS %}
+        <div class="alert alert-info">
+            Courant novembre 2024, <strong>ProConnect</strong> remplacera Inclusion Connect sur les services numériques de l’inclusion !
+            Vous recevrez des e-mails d’information tout au long de l’été et à la rentrée.
+        </div>
+    {% endif %}
 
     <h1 class="h2">Connexion</h1>
 
@@ -38,10 +40,23 @@
         {% include "includes/pe_connect.html" %}
     {% endif %}
 
-    <hr class="my-3 my-lg-4">
-    <div class="text-center">
-        <h2 class="h5">Vous n’avez pas de compte Inclusion Connect ?</h2>
-        <a href="{% url 'accounts:register' %}" class="btn btn-link matomo-event" data-matomo-category="authentification" data-matomo-action="clic" data-matomo-name="Créer mon compte">Créer mon compte</a>
-    </div>
+    {% if FREEZE_ACCOUNTS %}
+        <hr class="my-3 my-lg-4">
+        <div class="text-center">
+            <h2 class="h5">Vous n’avez pas de compte Inclusion Connect ?</h2>
+            <div class="alert alert-warning">
+                <p>
+                    Inclusion Connect devient ProConnect ! Depuis le 1er octobre 2024 la création de compte Inclusion Connect n’est plus possible. Veuillez vous rapprocher de votre fournisseur de service pour plus d’informations sur la mise à disposition de ProConnect, qui doit intervenir dans les meilleurs délais.
+                </p>
+                <a href="{{ MIGRATION_PAGE_URL }}" target="_blank" rel="noopener">Besoin d’aide ?</a>
+            </div>
+        </div>
+    {% else %}
+        <hr class="my-3 my-lg-4">
+        <div class="text-center">
+            <h2 class="h5">Vous n’avez pas de compte Inclusion Connect ?</h2>
+            <a href="{% url 'accounts:register' %}" class="btn btn-link matomo-event" data-matomo-category="authentification" data-matomo-action="clic" data-matomo-name="Créer mon compte">Créer mon compte</a>
+        </div>
+    {% endif %}
 
 {% endblock %}

--- a/inclusion_connect/templates/no_confirm_email.html
+++ b/inclusion_connect/templates/no_confirm_email.html
@@ -1,0 +1,24 @@
+{% extends "layout/left_content.html" %}
+{% load django_bootstrap5 %}
+{% load inclusionconnect_fields %}
+
+{% block content %}
+
+    <h1 class="h2">Impossible de confirmer votre adresse e-mail</h1>
+
+    <div class="alert alert-warning">
+        <p>
+            Inclusion Connect devient ProConnect ! Depuis le 1er octobre 2024 la création de compte ou le changement d'adresse e-mail sur Inclusion Connect n’est plus possible.
+        </p>
+        <p>
+            Vous avez déjà un compte Inclusion Connect ?
+            <a href="{% url 'login' %}" class="btn btn-link matomo-event" data-matomo-category="inscription" data-matomo-action="clic" data-matomo-name="Connectez-vous">cliquez ici</a>
+            pour vous connecter.
+        </p>
+        <p>
+            Sinon, veuillez vous rapprocher de votre fournisseur de service pour plus d’informations sur la mise à disposition de ProConnect, qui doit intervenir dans les meilleurs délais.
+        </p>
+        <a href="{{ MIGRATION_PAGE_URL }}" target="_blank" rel="noopener">Besoin d’aide ?</a>
+    </div>
+
+{% endblock %}

--- a/inclusion_connect/templates/no_register.html
+++ b/inclusion_connect/templates/no_register.html
@@ -1,0 +1,24 @@
+{% extends "layout/left_content.html" %}
+{% load django_bootstrap5 %}
+{% load inclusionconnect_fields %}
+
+{% block content %}
+
+    <h1 class="h2">Créer un compte</h1>
+
+    <div class="alert alert-warning">
+        <p>
+            Inclusion Connect devient ProConnect ! Depuis le 1er octobre 2024 la création de compte Inclusion Connect n’est plus possible.
+        </p>
+        <p>
+            Vous avez déjà un compte Inclusion Connect ?
+            <a href="{% url 'login' %}" class="btn btn-link matomo-event" data-matomo-category="inscription" data-matomo-action="clic" data-matomo-name="Connectez-vous">cliquez ici</a>
+            pour vous connecter.
+        </p>
+        <p>
+            Sinon, veuillez vous rapprocher de votre fournisseur de service pour plus d’informations sur la mise à disposition de ProConnect, qui doit intervenir dans les meilleurs délais.
+        </p>
+        <a href="{{ MIGRATION_PAGE_URL }}" target="_blank" rel="noopener">Besoin d’aide ?</a>
+    </div>
+
+{% endblock %}

--- a/inclusion_connect/utils/context_processors.py
+++ b/inclusion_connect/utils/context_processors.py
@@ -6,6 +6,8 @@ def expose_settings(*args):
         key: getattr(settings, key)
         for key in [
             "FAQ_URL",
+            "FREEZE_ACCOUNTS",
+            "MIGRATION_PAGE_URL",
             "PRIVACY_POLICY_PATH",
             "TERMS_PATH",
             "LEGAL_NOTICES_PATH",


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/gip-inclusion/Mettre-en-place-un-switch-sur-IC-pour-bloquer-la-cr-ation-de-compte-au-moment-de-faire-la-bascule-ve-b422026dde554f279f3f92676a3ecdf6?pvs=4


TODO: bloquer la mise à jour d'email en suivant le lien de confirmation
