### PR TITLE
settings: update Sentry loader script address

### DIFF
--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -388,7 +388,7 @@ CSP_SCRIPT_SRC = [
     "'self'",
     # https://docs.sentry.io/platforms/javascript/install/loader/#content-security-policy
     "https://browser.sentry-cdn.com",
-    "https://js.sentry-cdn.com",
+    "https://js-de.sentry-cdn.com",
 ]
 CSP_CONNECT_SRC = ["'self'", "*.sentry.io"]
 CSP_OBJECT_SRC = ["'none'"]

--- a/inclusion_connect/templates/layout/base.html
+++ b/inclusion_connect/templates/layout/base.html
@@ -15,7 +15,7 @@
         <link rel="stylesheet" href="{% static "css/inclusion_connect.css" %}">
 
         {% if not debug %}
-            <script src="https://js.sentry-cdn.com/d9163858ff954fc9a789fcb17662e1d2.min.js" crossorigin="anonymous"></script>
+            <script src="https://js-de.sentry-cdn.com/2e783f79f9df11a617ac43719eee20bf.min.js" crossorigin="anonymous"></script>
         {% endif %}
 
         {% block extra_head %}{% endblock %}

--- a/tests/__snapshots__/test_builtin_views.ambr
+++ b/tests/__snapshots__/test_builtin_views.ambr
@@ -14,7 +14,7 @@
           <link href="/static/css/inclusion_connect.css" rel="stylesheet"/>
   
           
-              <script crossorigin="anonymous" src="https://js.sentry-cdn.com/d9163858ff954fc9a789fcb17662e1d2.min.js"></script>
+              <script crossorigin="anonymous" src="https://js-de.sentry-cdn.com/2e783f79f9df11a617ac43719eee20bf.min.js"></script>
           
   
           

--- a/tests/__snapshots__/test_homepage.ambr
+++ b/tests/__snapshots__/test_homepage.ambr
@@ -14,7 +14,7 @@
           <link href="/static/css/inclusion_connect.css" rel="stylesheet"/>
   
           
-              <script crossorigin="anonymous" src="https://js.sentry-cdn.com/d9163858ff954fc9a789fcb17662e1d2.min.js"></script>
+              <script crossorigin="anonymous" src="https://js-de.sentry-cdn.com/2e783f79f9df11a617ac43719eee20bf.min.js"></script>
           
   
           


### PR DESCRIPTION
### Pourquoi ?

L'organisation Sentry a changé: le DSN a été mis à jour mais le _loader script_ doit aussi être adapté.

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

