### PR TITLE
Rendre l'email obligatoire

### DIFF
--- a/inclusion_connect/users/migrations/0001_initial.py
+++ b/inclusion_connect/users/migrations/0001_initial.py
@@ -73,9 +73,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "email",
-                    citext.fields.CIEmailField(
-                        blank=True, db_index=True, max_length=254, verbose_name="adresse e-mail"
-                    ),
+                    citext.fields.CIEmailField(db_index=True, max_length=254, verbose_name="adresse e-mail"),
                 ),
                 ("password", models.CharField(max_length=256, verbose_name="mot de passe")),
                 ("password_is_temporary", models.BooleanField(default=False, verbose_name="mot de passe temporaire")),

--- a/inclusion_connect/users/models.py
+++ b/inclusion_connect/users/models.py
@@ -21,7 +21,7 @@ class User(AbstractUser):
     # Change default id to uuid4 (used as sub in OIDC protocol) and use as pk
     username = models.UUIDField(unique=True, default=uuid.uuid4, editable=False, primary_key=True)
 
-    email = CIEmailField(verbose_name="adresse e-mail", blank=True, db_index=True)
+    email = CIEmailField(verbose_name="adresse e-mail", db_index=True)
     password = models.CharField("mot de passe", max_length=256)  # allow compat with old keycloak passwords
 
     # Triggers for required actions


### PR DESCRIPTION
### Pourquoi ?

On ne gère plus la confirmation d'email, ils seront gérés à la main dans l'admin

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

