### PR TITLE
feat: Add usual_name claim to OIDC tokens

### DIFF
--- a/docs/inclusion_connect.md
+++ b/docs/inclusion_connect.md
@@ -177,6 +177,7 @@ L'_id token_ est un objet JWT signé qui contient notamment :
 - **given_name** : le prénom de l'utilisateur.
 - **family_name** : son nom de famille.
 - **email** : son adresse e-mail.
+- **usual_name** : son nom d'usage (identique à `family_name`).
 
 
 La signature du token est chiffrée avec l'algorithme `RS256` et il est possible de récupérer la clé publique pour vérifier la signature.
@@ -218,6 +219,7 @@ Corps HTTP:
     'given_name': <prénom>,
     'family_name': <nom de famille>
     'email': <l'email>
+    'usual_name': <nom d'usage (= family_name)>
 }
 ```
 

--- a/inclusion_connect/oidc_overrides/validators.py
+++ b/inclusion_connect/oidc_overrides/validators.py
@@ -10,6 +10,7 @@ class CustomOAuth2Validator(OAuth2Validator):
             "permissions": "permissions",
             "site_pe": "profile",
             "structure_pe": "profile",
+            "usual_name": "profile",
         }
     )
 
@@ -20,4 +21,5 @@ class CustomOAuth2Validator(OAuth2Validator):
             "given_name": request.user.first_name,
             "family_name": request.user.last_name,
             "email": request.user.email,
+            "usual_name": request.user.last_name,
         }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -69,6 +69,7 @@ def oidc_flow_followup(
     assert decoded_id_token["given_name"] == user.first_name
     assert decoded_id_token["family_name"] == user.last_name
     assert decoded_id_token["email"] == user.email
+    assert decoded_id_token["usual_name"] == user.last_name
     for k, v in (additional_claims or {}).items():
         assert decoded_id_token[k] == v
 
@@ -82,6 +83,7 @@ def oidc_flow_followup(
         "given_name": user.first_name,
         "family_name": user.last_name,
         "email": user.email,
+        "usual_name": user.last_name,
     } | (additional_claims or {})
     assertRecords(caplog, [])
 


### PR DESCRIPTION
### Pourquoi ?

MAJ des scopes pour PC : https://partenaires.proconnect.gouv.fr/docs/fournisseur-identite/configuration#31-scopes

### Comment

Plutot que de construire un nouveau champ j'ai map le last_name sur usual_name. Le SIRET sera aussi a ajouter mais j'ai un doute sur le comment (var d'env, default value pour les users peut-etre)



