### PR TITLE
feat: Pise en charge des scopes de ProConnect

### DIFF
--- a/docs/inclusion_connect.md
+++ b/docs/inclusion_connect.md
@@ -174,10 +174,7 @@ L'_access token_ sera ensuite utilisé pour accéder à l'endpoint _UserInfo_.
 L'_id token_ est un objet JWT signé qui contient notamment :
 - **nonce** : la valeur transmise lors de la requête initiale qu'il faut vérifier.
 - **sub** : l'identifiant unique de l'utilisateur que le FS doit conserver au cas où l'utilisateur change son adresse e-mail un jour.
-- **given_name** : le prénom de l'utilisateur.
-- **family_name** : son nom de famille.
-- **email** : son adresse e-mail.
-
+- les données additionnelles demandées dans le **scope**
 
 La signature du token est chiffrée avec l'algorithme `RS256` et il est possible de récupérer la clé publique pour vérifier la signature.
 
@@ -215,6 +212,7 @@ Corps HTTP:
 ```
 {
     'sub': <l'identifiant unique de l'utilisateur>
+    # Eventuellement en fonction des scopes transmis
     'given_name': <prénom>,
     'family_name': <nom de famille>
     'email': <l'email>

--- a/docs/inclusion_connect.md
+++ b/docs/inclusion_connect.md
@@ -14,8 +14,6 @@ Le format des urls est le suivant :
 |               |                                       |
 |           --- | ---                                   |
 | Authorization | https://{hostname}/auth/authorize     |
-| Registration  | https://{hostname}/auth/register      |
-| Activation    | https://{hostname}/auth/activate      |
 | Token         | https://{hostname}/auth/token         |
 | UserInfo      | https://{hostname}/auth/userinfo      |
 | Logout        | https://{hostname}/auth/logout        |
@@ -88,28 +86,6 @@ Une fois sur Inclusion Connect, il y a 3 possibilités.
 - Si c'est un nouvel utilisateur, il devra se créer un compte, puis recevra un email de vérification d'adresse email qui le renverra sur Inclusion Connect avant d'être redirigé sur **redirect_uri**.
 - Si c'est un utilisateur existant non connecté, il devra entrer ses identifiants et sera ensuite redirigé sur **redirect_uri**.
 - Si c'est un utilisateur déjà connecté, il sera directement redirigé sur **redirect_uri**.
-
-#### Requête (Création de compte)
-
-Il est possible d'utiliser l'endpoint _Registration_ pour que l'utilisateur arrive directement sur cette seconde page.
-
-- URL : `https://{hostname}/auth/register?response_type=code&client_id=<CLIENT_ID>&redirect_uri=<FS_URL>%2F<URL_CALLBACK>&scope=<SCOPES>&state=><STATE>&nonce=<NONCE>`
-- Méthode : GET
-
-Les paramètres sont les mêmes que pour l'Authentification.
-
-#### Requête (Activation de compte)
-
-Il est possible d'utiliser l'endpoint _Activation_ pour que l'utilisateur arrive directement sur une page de création de compte pré-remplie.
-
-- URL : `https://{hostname}/auth/activate?response_type=code&client_id=<CLIENT_ID>&redirect_uri=<FS_URL>%2F<URL_CALLBACK>&scope=<SCOPES>&state=><STATE>&nonce=<NONCE>`
-- Méthode : GET
-
-Les paramètres sont les mêmes que pour l'Authentification, plus :
-- **login_hint**: devient obligatoire
-- **firstname**: permet de pré-remplir le prénom de l'utilisateur
-- **lastname**: permet de pré-remplir le nom de famille de l'utilisateur
-Sur cette page, ces informations ne sont pas modifiables. Cela permet de s'assurer qu'un utilisateur existant d'une plateforme qui migre son compte à Inclusion Connect ne change pas ses informations personnelles.
 
 #### Réponse
 

--- a/inclusion_connect/oidc_overrides/validators.py
+++ b/inclusion_connect/oidc_overrides/validators.py
@@ -1,23 +1,35 @@
+from django.conf import settings
 from oauth2_provider.oauth2_validators import OAuth2Validator
 
 
 class CustomOAuth2Validator(OAuth2Validator):
-    # Extend the standard scopes to add a new "permissions" scope
-    # which returns a "permissions" claim:
     oidc_claim_scope = OAuth2Validator.oidc_claim_scope
     oidc_claim_scope.update(
         {
-            "permissions": "permissions",
-            "site_pe": "profile",
-            "structure_pe": "profile",
+            "siret": "siret",
+            "siren": "siren",
+            "usual_name": "usual_name",
+            "uid": "uid",
         }
     )
 
-    def get_additional_claims(self, request):
-        """Add data to the Id Token"""
-
-        return {
+    def get_claim_dict(self, request):
+        return super().get_claim_dict(request) | {
+            "email": request.user.email,
             "given_name": request.user.first_name,
             "family_name": request.user.last_name,
-            "email": request.user.email,
+            "usual_name": request.user.last_name,
+            "uid": str(request.user.pk),
+            "siret": settings.SIRET,
+            "siren": settings.SIRET[:9],
         }
+
+    def get_oidc_claims(self, token, token_handler, request):
+        claims = super().get_oidc_claims(token, token_handler, request)
+        # Proconnect asks for "given_name" by adding it to the scopes
+        # where it's expected to be in the "profile" scope (see OAuth2Validator.oidc_claim_scope)
+        data = self.get_claim_dict(request)
+        for k, v in data.items():
+            if k in request.scopes and k not in claims:
+                claims[k] = v
+        return claims

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -307,6 +307,17 @@ OAUTH2_PROVIDER = {
         "openid": "OpenID Connect scope",
         "profile": "Profil utilisateur",
         "email": "Email de l'utilisateur",
+        # ProConnect specific scopes
+        "siret": "Siret de la structure de rattachement",
+        "given_name": "Prénom de l'utilisateur",
+        "usual_name": "Nom de famille de l'utilisateur",
+        "uid": "Identifiant unique de l'utilisateur",
+        "siren": "SIREN de la structure",
+        # ProConnect unused specific scopes
+        "organizational_unit": "Non implémenté",
+        "belonging_population": "Non implémenté",
+        "phone": "Non implémenté",
+        "chorusdt": "Non implémenté",
     },
     "PKCE_REQUIRED": False,
     "OAUTH2_VALIDATOR_CLASS": "inclusion_connect.oidc_overrides.validators.CustomOAuth2Validator",
@@ -355,3 +366,5 @@ if cors_allowed_origins and not CORS_ALLOW_ALL_ORIGINS:
 
 
 LOGOUT_REDIRECT_URL = "/accounts/login/"
+
+SIRET = "13003013300016"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,6 +28,13 @@ def oidc_flow_followup(
     code_verifier=None,
     with_trailing_slash=False,
 ):
+    additional_claims = additional_claims or {
+        # defauld claims for "openid profile email"
+        "given_name": user.first_name,
+        "family_name": user.last_name,
+        "email": user.email,
+    }
+
     # Call TOKEN endpoint
     token_data = {
         "client_id": oidc_params["client_id"],
@@ -66,9 +73,6 @@ def oidc_flow_followup(
     assert decoded_id_token["nonce"] == oidc_params["nonce"]
     assert decoded_id_token["sub"] == str(user.pk)
     assert uuid.UUID(decoded_id_token["sub"]), "Sub should be an uuid"
-    assert decoded_id_token["given_name"] == user.first_name
-    assert decoded_id_token["family_name"] == user.last_name
-    assert decoded_id_token["email"] == user.email
     for k, v in (additional_claims or {}).items():
         assert decoded_id_token[k] == v
 
@@ -77,12 +81,7 @@ def oidc_flow_followup(
         "/auth/userinfo" + ("/" if with_trailing_slash else ""),
         headers={"Authorization": f"Bearer {token_json['access_token']}"},
     )
-    assert response.json() == {
-        "sub": str(user.pk),
-        "given_name": user.first_name,
-        "family_name": user.last_name,
-        "email": user.email,
-    } | (additional_claims or {})
+    assert response.json() == {"sub": str(user.pk)} | additional_claims
     assertRecords(caplog, [])
 
     return token_json["id_token"]

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -823,3 +823,92 @@ def test_base_url_redirect(client):
     client.force_login(UserFactory())
     response = client.get(reverse("index"))
     assertRedirects(response, reverse("accounts:home"))
+
+
+@freeze_time("2023-05-05 11:11:11")
+def test_proconnect_scopes(caplog, client, oidc_params):
+    # See https://partenaires.proconnect.gouv.fr/docs/fournisseur-identite/configuration#31-scopes
+    oidc_params["scope"] = " ".join(
+        [
+            "openid",
+            "given_name",
+            "usual_name",
+            "email",
+            "uid",
+            "siren",
+            "siret",
+            "organizational_unit",
+            "belonging_population",
+            "phone",
+            "chorusdt",
+        ]
+    )
+    auth_url = reverse("oauth2_provider:authorize")
+    ApplicationFactory(client_id=oidc_params["client_id"])
+    user = UserFactory()
+
+    auth_complete_url = add_url_params(auth_url, oidc_params)
+    response = client.get(auth_complete_url)
+    assertRedirects(response, reverse("accounts:login"))
+    assertRecords(caplog, [])
+
+    response = client.post(
+        response.url,
+        data={
+            "email": user.email,
+            "password": DEFAULT_PASSWORD,
+        },
+    )
+    assertRedirects(response, auth_complete_url, fetch_redirect_response=False)
+    assert get_user(client).is_authenticated is True
+    user = User.objects.get(email=user.email)
+    assert user.linked_applications.count() == 0
+    assertRecords(
+        caplog,
+        [
+            (
+                "inclusion_connect.auth",
+                logging.INFO,
+                {"application": "my_application", "user": user.email, "event": "login"},
+            )
+        ],
+    )
+
+    response = client.get(auth_complete_url)
+    assert response.status_code == 302
+    assert response.url.startswith(oidc_params["redirect_uri"])
+    auth_response_params = get_url_params(response.url)
+    assert user.linked_applications.count() == 1
+    code = auth_response_params["code"]
+    assertRecords(
+        caplog,
+        [
+            (
+                "inclusion_connect.oidc",
+                logging.INFO,
+                {
+                    "application": "my_application",
+                    "event": "redirect",
+                    "user": user.email,
+                    "url": f"http://localhost/callback?code={code}&state=state",
+                },
+            )
+        ],
+    )
+
+    oidc_flow_followup(
+        client,
+        auth_response_params,
+        user,
+        oidc_params,
+        caplog,
+        additional_claims={
+            "sub": str(user.pk),
+            "email": user.email,
+            "siret": "13003013300016",
+            "siren": "130030133",
+            "usual_name": user.last_name,
+            "given_name": user.first_name,
+            "uid": str(user.pk),
+        },
+    )


### PR DESCRIPTION
### Pourquoi ?

Voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-identite/configuration#31-scopes

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

