### PR TITLE
Sécurité: Forcer les administrateurs à mettre leur mot de passe

### DIFF
--- a/inclusion_connect/accounts/middleware.py
+++ b/inclusion_connect/accounts/middleware.py
@@ -15,10 +15,9 @@ def post_login_actions(get_response):
         user = request.user
 
         whitelisted_urls = [reverse("index"), reverse("oauth2_provider:rp-initiated-logout")]
-
         path_is_whitelisted = request.path in whitelisted_urls
 
-        if user.is_authenticated and user.is_staff is False and path_is_whitelisted is False:
+        if user.is_authenticated and path_is_whitelisted is False:
             next_action_url = required_action_url(user)
             if next_action_url and not request.path == next_action_url:
                 return HttpResponseRedirect(next_action_url)

--- a/tests/accounts/tests.py
+++ b/tests/accounts/tests.py
@@ -730,15 +730,6 @@ class TestMiddleware:
         response = client.get(reverse("accounts:change_password"))
         assert response.status_code == 200
 
-    def test_staff_users_are_not_concerned(self, client):
-        user = UserFactory(
-            password_is_temporary=True,
-            is_staff=True,
-        )
-        client.force_login(user)
-        response = client.get(reverse("admin:index"))
-        assert response.status_code == 200
-
     def test_logout_is_whitelisted(self, client):
         user = UserFactory(
             password_is_temporary=True,

--- a/tests/users/test_admin.py
+++ b/tests/users/test_admin.py
@@ -162,24 +162,26 @@ class TestUserAdmin:
         user = UserFactory(
             is_superuser=True,
             is_staff=True,
-            first_name="Admin",
-            last_name="Istrator",
-            email="admin@mailinator.net",
+        )
+        other_user = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            email="john.doe@mailinator.net",
             username="11111111-1111-1111-1111-111111111111",
         )
 
         result_id = '[class*="field-password_is_temporary"]'
 
         def get_password_form_field():
-            response = client.get(reverse("admin:users_user_change", kwargs={"object_id": user.pk}))
+            response = client.get(reverse("admin:users_user_change", kwargs={"object_id": other_user.pk}))
             assert response.status_code == 200
             return pretty_indented(parse_response_to_soup(response, selector=result_id))
 
         client.force_login(user)
         assert get_password_form_field() == snapshot(name="normal password")
 
-        user.password_is_temporary = True
-        user.save()
+        other_user.password_is_temporary = True
+        other_user.save()
         assert get_password_form_field() == snapshot(name="temporary password")
 
     def test_logout(self, client):


### PR DESCRIPTION
### Pourquoi ?

Il n'y a pas de raison de leur permettre de conserver un mot de passe faible ou temporaire

