### PR TITLE
Nettoyage: Suppression de l'ancien formulaire de connexion de l'admin

### DIFF
--- a/inclusion_connect/admin/sites.py
+++ b/inclusion_connect/admin/sites.py
@@ -1,18 +1,7 @@
-from django.contrib.admin import forms as admin_forms, sites as admin_sites
-
-from inclusion_connect.users.models import User
-
-
-class AdminAuthenticationForm(admin_forms.AdminAuthenticationForm):
-    def __init__(self, request=None, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["username"].widget.attrs["maxlength"] = User._meta.get_field("email").max_length
-        self.fields["username"].label = "Adresse e-mail"
+from django.contrib.admin import sites as admin_sites
 
 
 class AdminSite(admin_sites.AdminSite):
-    login_form = AdminAuthenticationForm
-
     site_header = "Administration Inclusion Connect"
     site_title = "Administration Inclusion Connect"
     index_title = None


### PR DESCRIPTION
### Pourquoi ?

Il n'est plus utilisé depuis  d49857e

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

