### PR TITLE
Ajouter le clail acr dans l'IdToken

### DIFF
--- a/inclusion_connect/oidc_overrides/validators.py
+++ b/inclusion_connect/oidc_overrides/validators.py
@@ -32,4 +32,5 @@ class CustomOAuth2Validator(OAuth2Validator):
         for k, v in data.items():
             if k in request.scopes and k not in claims:
                 claims[k] = v
+        claims["acr"] = "eidas2"  # We enfore 2FA TOTP and have a HR process to create accounts
         return claims

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -89,7 +89,7 @@ def oidc_flow_followup(
         "/auth/userinfo" + ("/" if with_trailing_slash else ""),
         headers={"Authorization": f"Bearer {token_json['access_token']}"},
     )
-    assert response.json() == {"sub": str(user.pk)} | additional_claims
+    assert response.json() == {"sub": str(user.pk), "acr": "eidas2"} | additional_claims
     assertRecords(caplog, [])
 
     return token_json["id_token"]


### PR DESCRIPTION
### Pourquoi ?

On force TOTP et on a un process de création de comptes donc on est compatible eidas2.
Voir https://partenaires.proconnect.gouv.fr/docs/fournisseur-identite/niveaux-assurance-eidas
