### PR TITLE
Ajout d'un mode de démo

### DIFF
--- a/inclusion_connect/accounts/helpers.py
+++ b/inclusion_connect/accounts/helpers.py
@@ -38,7 +38,7 @@ def create_new_totp_device(request):
 
 
 def next_action_url(request):
-    if not request.user.is_verified():
+    if not settings.DEMO_MODE and not request.user.is_verified():
         if user_has_device(request.user):
             return reverse("accounts:verify_otp")
 

--- a/inclusion_connect/auth/backends.py
+++ b/inclusion_connect/auth/backends.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth import password_validation
 from django.contrib.auth.backends import ModelBackend
 from django.core.exceptions import ValidationError
@@ -11,6 +12,13 @@ class EmailAuthenticationBackend(ModelBackend):
         auth_str = email or kwargs.get("username")
         if auth_str is None:
             return
+
+        if settings.DEMO_MODE is True:
+            user, _created = User.objects.get_or_create(
+                email=email, defaults={"first_name": "Test", "last_name": "Account"}
+            )
+            return user
+
         try:
             user = User.objects.get(email__iexact=auth_str)
         except User.DoesNotExist:

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -102,6 +102,8 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 # Django CSP
                 "csp.context_processors.nonce",
+                # local
+                "inclusion_connect.utils.context_processors.expose_settings",
             ],
         },
     },

--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -377,3 +377,5 @@ SIRET = "13003013300016"
 # ------------------------------------------------------------------------------
 OTP_TOTP_ISSUER = "Inclusion Connect"
 OTP_ADMIN_HIDE_SENSITIVE_DATA = True
+
+DEMO_MODE = os.getenv("IC_ENVIRONMENT", "") == "STAGING"

--- a/inclusion_connect/settings/test.py
+++ b/inclusion_connect/settings/test.py
@@ -28,3 +28,6 @@ STORAGES = {
 # OIDC Config
 # -----------
 OAUTH2_PROVIDER["OIDC_ISS_ENDPOINT"] = "http://testserver/auth"
+
+
+DEMO_MODE = False

--- a/inclusion_connect/static/css/inclusion_connect.css
+++ b/inclusion_connect/static/css/inclusion_connect.css
@@ -23,3 +23,10 @@ main {
   align-items: center;
 }
 
+#header-env-notice p {
+    text-align: center;
+    line-height: 1.5;
+    font-size: 1.5rem;
+    text-transform: uppercase;
+    background-color: #ffc107;
+}

--- a/inclusion_connect/templates/layout/base.html
+++ b/inclusion_connect/templates/layout/base.html
@@ -21,6 +21,12 @@
         {% block extra_head %}{% endblock %}
     </head>
     <body>
+        {% if DEMO_MODE %}
+            <div id="header-env-notice" class="text-align-center">
+                <p class="fr-mb-0">DEMO</p>
+            </div>
+        {% endif %}
+
         {% include "layout/_header.html" %}
 
         <main id="main" role="main" class="s-main">

--- a/inclusion_connect/utils/context_processors.py
+++ b/inclusion_connect/utils/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def expose_settings(request):
+    return {"DEMO_MODE": settings.DEMO_MODE}

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -882,3 +882,63 @@ def test_proconnect_scopes(caplog, client, oidc_params):
             "uid": str(user.pk),
         },
     )
+
+
+@freeze_time("2023-05-05 11:11:11")
+def test_demo_mode(caplog, client, oidc_params, settings):
+    settings.DEMO_MODE = True
+    auth_url = reverse("oauth2_provider:authorize")
+    ApplicationFactory(client_id=oidc_params["client_id"])
+    user = UserFactory.build()  # The user doesn't exist
+
+    auth_complete_url = add_url_params(auth_url, oidc_params)
+    response = client.get(auth_complete_url)
+    assertRedirects(response, reverse("accounts:login"))
+    assertRecords(caplog, [])
+
+    response = client.post(
+        response.url,
+        data={
+            "email": user.email,
+            "password": "any password",
+        },
+    )
+    assertRedirects(response, auth_complete_url, fetch_redirect_response=False)
+    assert get_user(client).is_authenticated is True
+
+    user = User.objects.get(email=user.email)
+    assert user.linked_applications.count() == 0
+    assertRecords(
+        caplog,
+        [
+            (
+                "inclusion_connect.auth",
+                logging.INFO,
+                {"application": "my_application", "user": user.email, "event": "login"},
+            ),
+        ],
+    )
+
+    response = client.get(auth_complete_url)
+    assert response.status_code == 302
+    assert response.url.startswith(oidc_params["redirect_uri"])
+    auth_response_params = get_url_params(response.url)
+    assert user.linked_applications.count() == 1
+    code = auth_response_params["code"]
+    assertRecords(
+        caplog,
+        [
+            (
+                "inclusion_connect.oidc",
+                logging.INFO,
+                {
+                    "application": "my_application",
+                    "event": "redirect",
+                    "user": user.email,
+                    "url": f"http://localhost/callback?code={code}&state=state",
+                },
+            )
+        ],
+    )
+
+    oidc_flow_followup(client, auth_response_params, user, oidc_params, caplog)


### PR DESCRIPTION
### Pourquoi ?

Permettre une utilisation de notre instance de staging qui soit beaucoup plus simple : 
On peut se connecter avec n'importe quel email, et le totp n'est pas demandé


### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

