### PR TITLE
Sécurité: Ne plus importer les urls auth de Django

### DIFF
--- a/inclusion_connect/urls.py
+++ b/inclusion_connect/urls.py
@@ -30,7 +30,6 @@ urlpatterns = [
     path("", views.index, name="index"),
     # Login urls
     re_path(r"^accounts/", include("inclusion_connect.accounts.urls")),
-    re_path(r"^accounts/", include("django.contrib.auth.urls")),
     # OIDC provider urls
     re_path(r"^auth/", include("inclusion_connect.oidc_overrides.urls", namespace="oauth2_provider")),
     # security.txt page

--- a/inclusion_connect/users/models.py
+++ b/inclusion_connect/users/models.py
@@ -56,7 +56,7 @@ class User(AbstractUser):
         uid = urlsafe_base64_encode(force_bytes(self.pk))
         token = default_token_generator.make_token(self)
         path = reverse(
-            "password_reset_confirm",
+            "accounts:password_reset_confirm",
             kwargs={
                 "uidb64": uid,
                 "token": token,


### PR DESCRIPTION
### Pourquoi ?

On ne veut pas les utiliser

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

