### PR TITLE
feat: AJout d'un bandeau de démo

### DIFF
--- a/inclusion_connect/settings/base.py
+++ b/inclusion_connect/settings/base.py
@@ -33,6 +33,7 @@ SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
+ENVIRONMENT = os.getenv("IC_ENVIRONMENT")
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "connect.inclusion.beta.gouv.fr").split(",")
 
@@ -101,6 +102,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "django.template.context_processors.csp",
+                "inclusion_connect.utils.context_processors.expose_settings",
             ],
         },
     },

--- a/inclusion_connect/static/css/inclusion_connect.css
+++ b/inclusion_connect/static/css/inclusion_connect.css
@@ -23,3 +23,9 @@ main {
   align-items: center;
 }
 
+#debug-mode-banner {
+  background-color: #d10000;
+  color: #ffffff;
+  text-align: center;
+  padding: 0.5em;
+}

--- a/inclusion_connect/templates/layout/base.html
+++ b/inclusion_connect/templates/layout/base.html
@@ -21,6 +21,13 @@
         {% block extra_head %}{% endblock %}
     </head>
     <body>
+        {% if ENVIRONMENT and ENVIRONMENT != "PROD" %}
+            <div id="debug-mode-banner">
+                <p class="mb-0">
+                    <strong class="text-uppercase">DÉMO</strong>
+                </p>
+            </div>
+        {% endif %}
         {% include "layout/_header.html" %}
 
         <main id="main" role="main" class="s-main">

--- a/inclusion_connect/templates/layout/base.html
+++ b/inclusion_connect/templates/layout/base.html
@@ -36,7 +36,8 @@
                 <div class="container">
                     <div class="row g-0 bg-white">
                         {% block full_content %}
-                            {% block left_content %}{% endblock %}
+                            {% block left_content %}
+                            {% endblock %}
                             {% block right_content %}{% endblock %}
                         {% endblock %}
                     </div>

--- a/inclusion_connect/utils/context_processors.py
+++ b/inclusion_connect/utils/context_processors.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+
+
+def expose_settings(request):
+    """
+    Put things into the context to make them available in templates.
+    https://docs.djangoproject.com/en/4.1/ref/templates/api/#using-requestcontext
+    """
+
+    return {
+        "ENVIRONMENT": settings.ENVIRONMENT,
+    }

--- a/tests/test_builtin_views.py
+++ b/tests/test_builtin_views.py
@@ -1,9 +1,11 @@
+from django.test import override_settings
 from django.urls import reverse
 
 from tests.conftest import Client
 from tests.helpers import parse_response_to_soup, pretty_indented
 
 
+@override_settings(ENVIRONMENT="PROD")
 def test_csrf_view(snapshot):
     client = Client(enforce_csrf_checks=True)
     response = client.post(


### PR DESCRIPTION
### Pourquoi ?

Pour simplifier les demande de support 

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

<img width="1486" height="311" alt="image" src="https://github.com/user-attachments/assets/424c9968-809b-48ab-8923-691bfe0bca2d" />
